### PR TITLE
Error in name reported by Jonathan Kew

### DIFF
--- a/languoids/tree/indoeuropean.indo1319/indoiranian.indo1320/indoaryan.indo1321/indoaryannorthernzone.indo1310/himachali.hima1250/nuclearhimachali.nucl1728/kullupahari.kull1236/kllui.kllu1238/kllui.kllu1238.ini
+++ b/languoids/tree/indoeuropean.indo1319/indoiranian.indo1320/indoaryan.indo1321/indoaryannorthernzone.indo1310/himachali.hima1250/nuclearhimachali.nucl1728/kullupahari.kull1236/kllui.kllu1238/kllui.kllu1238.ini
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 [core]
-name = Kllui
+name = Kullui
 glottocode = kllu1238
 level = dialect
 macroareas = 


### PR DESCRIPTION
Jonathan Kew notes:

> The name "Kllui" must be a typo: it should be "Kului" or "Kullui". Whether to double the "l" in the name is debatable (the double-ll spelling of the name of "Kullu" town/district seems to be more common on the Internet, although when I was in the area in the 1980s I had the impression the single-l spelling was more usual). But omitting the first "u" cannot be right. 