### PR TITLE
Update oowe1239.ini

### DIFF
--- a/languoids/tree/waka1280/nort2964/kwak1268/heil1246/oowe1239/oowe1239.ini
+++ b/languoids/tree/waka1280/nort2964/kwak1268/heil1246/oowe1239/oowe1239.ini
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 [core]
-name = Ooweekeeno
+name = Oowekyala
 glottocode = oowe1239
 level = dialect
 macroareas = 


### PR DESCRIPTION
Changed from Ooweekeeno because Mura (2015) uses the new name Oowekyala, so presumably this is more current.