### PR TITLE
Update cent2017.ini

### DIFF
--- a/languoids/tree/atla1278/limb1267/west2450/cent2017/cent2017.ini
+++ b/languoids/tree/atla1278/limb1267/west2450/cent2017/cent2017.ini
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 [core]
-name = Central
+name = Central Limba
 glottocode = cent2017
 level = dialect
 macroareas = 


### PR DESCRIPTION
A dialect name should never be called just "Central".