### PR TITLE
Update kxoe1243.ini

### DIFF
--- a/languoids/tree/khoe1240/khoe1241/nonk1236/west2506/kxoe1242/kxoe1243/kxoe1243.ini
+++ b/languoids/tree/khoe1240/khoe1241/nonk1236/west2506/kxoe1242/kxoe1243/kxoe1243.ini
@@ -5,8 +5,8 @@ glottocode = kxoe1243
 hid = xuu
 level = language
 iso639-3 = xuu
-latitude = -16.5905
-longitude = 22.5998
+latitude = -17.8193
+longitude = 23.9536
 macroareas = 
 	Africa
 countries = 


### PR DESCRIPTION
Changed lat/long to those of Rundu in the West Caprivi, which is nowadays the main settlement area of Khwe-speakers; previous lat/long implied that Khwe is a language of Zambia, which is not actually the case