### PR TITLE
Update location of Pennsylvania German

### DIFF
--- a/languoids/tree/indo1319/germ1287/nort3152/west2793/fran1268/high1287/pala1355/penn1240/penn1240.ini
+++ b/languoids/tree/indo1319/germ1287/nort3152/west2793/fran1268/high1287/pala1355/penn1240/penn1240.ini
@@ -5,8 +5,8 @@ glottocode = penn1240
 hid = pdc
 level = language
 iso639-3 = pdc
-latitude = 47.3341
-longitude = -87.8064
+latitude = 40.030507
+longitude = -76.32110
 macroareas = 
 	North America
 countries = 


### PR DESCRIPTION
According to Neele Müller

> dann würde ich vorschlagen als Center die Stadt Lancaster in Lancaster
> County, PA, zu nehmen (40.030507, -76.32110 laut google maps). Die
> Sprecherzahlen sind nie wirklich komplett erhoben worden, aber das
> County in PA ist auf jeden Fall eines mit der höchsten
> Sprecherdichte/Zahl in den USA und die Sprecherzahl in CAN ist auf jeden
> Fall deutlich niedriger.