### PR TITLE
Update location of Penange

### DIFF
--- a/languoids/tree/dogo1299/west2779/pena1270/pena1270.ini
+++ b/languoids/tree/dogo1299/west2779/pena1270/pena1270.ini
@@ -5,7 +5,7 @@ glottocode = pena1270
 hid = NOCODE_Penange
 level = language
 latitude = 14.38
-longitude = 4.03
+longitude = -4.03
 macroareas = 
 	Africa
 countries = 


### PR DESCRIPTION
Jeff Heath notes:

> Penange is in the wrong place, longitude should be minus (not plus) 4.03, i.e. west not east