### PR TITLE
Make refs searchable using the Whoosh search engine

### DIFF
--- a/pyglottolog/fts.py
+++ b/pyglottolog/fts.py
@@ -1,0 +1,76 @@
+# coding: utf8
+from __future__ import unicode_literals, print_function, division
+
+import attr
+from whoosh import index
+from whoosh.fields import Schema, TEXT, KEYWORD, ID
+from whoosh.analysis import StemmingAnalyzer
+from whoosh.qparser import QueryParser
+
+from clldutils.path import rmtree
+from clldutils.misc import slug
+
+from pyglottolog.util import build_path
+from pyglottolog.monsterlib._bibtex import iterentries
+
+
+@attr.s
+class Document(object):
+    id = attr.ib()
+    title = attr.ib()
+    author = attr.ib()
+    authoryear = attr.ib()
+    year = attr.ib()
+    doctype = attr.ib()
+
+
+def get_index(repos=None, recreate=False):
+    index_dir = build_path('whoosh', repos=repos)
+    if index_dir.exists() and recreate:
+        rmtree(index_dir)
+    if not index_dir.exists():
+        index_dir.mkdir()
+        schema = Schema(
+            id=ID(stored=True),
+            authoryear=TEXT(stored=True),
+            title=TEXT(analyzer=StemmingAnalyzer(), stored=True),
+            author=TEXT(stored=True),
+            year=TEXT(stored=True),
+            doctype=TEXT(stored=True),
+            body=TEXT(),
+            tags=KEYWORD)
+        return index.create_in(index_dir.as_posix(), schema)
+    return index.open_dir(index_dir.as_posix())
+
+
+def search(q, limit=1000, **kw):
+    index_ = get_index(repos=kw.pop('repos', None))
+    qp = QueryParser("body", schema=index_.schema)
+    q = '{0} {1}'.format(q, ' '.join('{0}:"{1}"'.format(k, v) for k, v in kw.items()))
+
+    with index_.searcher() as searcher:
+        results = searcher.search(qp.parse(q), limit=limit)
+        return len(results), [Document(**res) for res in results]
+
+
+def build_index(repos, monster):
+    writer = get_index(recreate=True, repos=repos).writer()
+    no_id = 0
+    for id_, (type_, fields) in iterentries(monster):
+        if 'glottolog_ref_id' not in fields:
+            no_id += 1
+            continue
+        author = fields.get('author', '')
+        if author:
+            author = slug(author.split()[0])
+        writer.add_document(
+            id=fields['glottolog_ref_id'],
+            title=fields.get('title', fields.get('booktitle', '')),
+            author=fields.get('author', fields.get('editor', '')),
+            year=fields.get('year', ''),
+            doctype=fields.get('hhtype', ''),
+            body='%s' % fields,
+            authoryear='{0}{1}'.format(author, fields.get('year', '')).lower())
+    writer.commit()
+    if no_id:
+        print('{0} entries without ref ID'.format(no_id))

--- a/pyglottolog/monsterlib/_bibtex.py
+++ b/pyglottolog/monsterlib/_bibtex.py
@@ -14,6 +14,8 @@ from pybtex.textutils import whitespace_re
 from pybtex.bibtex.utils import split_name_list
 from pybtex.database import Person
 
+from clldutils.path import as_posix
+
 
 FIELDORDER = [
     'author', 'editor', 'title', 'booktitle', 'journal',
@@ -24,7 +26,7 @@ FIELDORDER = [
 
 @contextlib.contextmanager
 def memorymapped(filename, access=mmap.ACCESS_READ):
-    fd = open(filename)
+    fd = open(as_posix(filename))
     try:
         m = mmap.mmap(fd.fileno(), 0, access=access)
     except:  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,12 @@ requires = [
     # list required third-party packages here
     'six',
     'enum34',
-    'clldutils>=1.2.1',
+    'clldutils>=1.5.5',
     'pybtex>=0.20',
     'latexcodec',
     'unidecode',
+    'whoosh',
+    'attrs',
 ]
 
 setup(


### PR DESCRIPTION
This PR adds two subcommands to the `glottolog` command:
- `ftsindex`: Index the contents of `monster-utf8.bib`. If the bibfile
  does not exist in the `build` directory, it will be created running
  `compile_monster`. The whole process may take tens of minutes.
- `search`: Search the references using the index.
```
$ glottolog search 'author:Dixon author:Blake title:Australian title:handbook year:198*'
2 matches
  ID  Author                                 Year  Title
----  -----------------------------------  ------  ---------------------------------------
6127  Dixon, R. M. W. and Blake, Barry J.    1981  Handbook of Australian languages vol. 2
3745  Dixon, R. M. W. and Blake, Barry J.    1983  Handbook of Australian languages vol. 3
```