### PR TITLE
removed invalid ISO codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ nosetests.xml
 .project
 .pydevproject
 .idea
-
+iso639-3

--- a/languoids/tree/gumu1250/sout3236/sout3236.ini
+++ b/languoids/tree/gumu1250/sout3236/sout3236.ini
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 [core]
 glottocode = sout3236
+hid = NOCODE_Southern-Gumuz
 name = Southern Gumuz
 level = language
-iso639-3 = NOCODE_Southern-Gumuz
 

--- a/languoids/tree/indo1319/germ1287/nort3152/nort3160/east2302/macr1265/jamt1238/jamt1238.ini
+++ b/languoids/tree/indo1319/germ1287/nort3152/nort3160/east2302/macr1265/jamt1238/jamt1238.ini
@@ -10,7 +10,6 @@ macroareas =
 	Eurasia
 countries = 
 	Sweden (SE)
-iso639-3 = jmk
 
 [sources]
 glottolog = 

--- a/languoids/tree/indo1319/germ1287/nort3152/nort3160/east2302/macr1265/scan1238/scan1238.ini
+++ b/languoids/tree/indo1319/germ1287/nort3152/nort3160/east2302/macr1265/scan1238/scan1238.ini
@@ -10,7 +10,6 @@ macroareas =
 	Eurasia
 countries = 
 	Sweden (SE)
-iso639-3 = scy
 
 [sources]
 glottolog = 

--- a/languoids/tree/sign1238/vill1244/fnqi1234/fnqi1234.ini
+++ b/languoids/tree/sign1238/vill1244/fnqi1234/fnqi1234.ini
@@ -4,5 +4,4 @@ glottocode = fnqi1234
 name = Far North Queensland Indigenous Sign Language
 level = language
 hid = NOCODE_Far-North-Queensland-Indigenous-Sign
-iso639-3 = NOCODE_Far-North-Queensland-Indigenous-Sign
 

--- a/languoids/tree/sino1245/burm1265/lolo1265/burm1266/nort2720/high1273/acha1252/lian1258/lian1258.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/burm1266/nort2720/high1273/acha1252/lian1258/lian1258.ini
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 [core]
 glottocode = lian1258
+hid = NOCODE_Lianghe-Achang
 name = Lianghe Achang
 level = language
-iso639-3 = NOCODE_Lianghe-Achang
 

--- a/languoids/tree/sino1245/burm1265/lolo1265/burm1266/nort2720/high1273/acha1252/luxi1238/luxi1238.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/burm1266/nort2720/high1273/acha1252/luxi1238/luxi1238.ini
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 [core]
 glottocode = luxi1238
+hid = NOCODE_Luxi-Achang
 name = Luxi Achang
 level = language
-iso639-3 = NOCODE_Luxi-Achang
 

--- a/languoids/tree/sino1245/burm1265/lolo1265/burm1266/nort2720/high1273/acha1252/ngoc1235/ngoc1235.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/burm1266/nort2720/high1273/acha1252/ngoc1235/ngoc1235.ini
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 [core]
 glottocode = ngoc1235
+hid = NOCODE_Ngochang
 name = Ngochang
 level = language
-iso639-3 = NOCODE_Ngochang
 

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/liso1234/nucl1734/lisu1252/lalu1234/lalo1240/ekaa1234/ekaa1234.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/liso1234/nucl1734/lisu1252/lalu1234/lalo1240/ekaa1234/ekaa1234.ini
@@ -10,7 +10,6 @@ macroareas =
 	Eurasia
 countries = 
 	China (CN)
-iso639-3 = ekb
 
 [sources]
 glottolog = 

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/liso1234/nucl1734/lisu1252/lalu1234/lalo1240/grea1292/xuzh1234/xuzh1234.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/liso1234/nucl1734/lisu1252/lalu1234/lalo1240/grea1292/xuzh1234/xuzh1234.ini
@@ -10,7 +10,6 @@ macroareas =
 	Eurasia
 countries = 
 	China (CN)
-iso639-3 = lxu
 
 [sources]
 glottolog = 

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/liso1234/nucl1734/lisu1252/lalu1234/lalo1240/sout3210/sout3210.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/liso1234/nucl1734/lisu1252/lalu1234/lalo1240/sout3210/sout3210.ini
@@ -10,7 +10,6 @@ macroareas =
 	Eurasia
 countries = 
 	China (CN)
-iso639-3 = svl
 
 [sources]
 glottolog = 

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/liso1234/nucl1734/lisu1252/lalu1234/lalo1240/yang1304/yang1304.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/liso1234/nucl1734/lisu1252/lalu1234/lalo1240/yang1304/yang1304.ini
@@ -10,7 +10,6 @@ macroareas =
 	Eurasia
 countries = 
 	China (CN)
-iso639-3 = lly
 
 [sources]
 glottolog = 

--- a/languoids/tree/sino1245/burm1265/naqi1236/qian1263/rgya1241/core1262/situ1238/situ1238.ini
+++ b/languoids/tree/sino1245/burm1265/naqi1236/qian1263/rgya1241/core1262/situ1238/situ1238.ini
@@ -10,7 +10,6 @@ macroareas =
 	Eurasia
 countries = 
 	China (CN)
-iso639-3 = tzi
 
 [sources]
 glottolog = 

--- a/pyglottolog/cli.py
+++ b/pyglottolog/cli.py
@@ -82,8 +82,9 @@ def missing_iso(args):
 
 
 def check_tree(args):
-    if args.args:
-        iso = ISO(args.args[0] if Path(args.args[0]).exists() else None)
+    iso_tables = list(args.repos.joinpath('iso639-3').glob('*.zip'))
+    if iso_tables:
+        iso = ISO(iso_tables[0])
     else:
         iso = None
 

--- a/pyglottolog/cli.py
+++ b/pyglottolog/cli.py
@@ -84,6 +84,7 @@ def missing_iso(args):
 def check_tree(args):
     iso_tables = list(args.repos.joinpath('iso639-3').glob('*.zip'))
     if iso_tables:
+        log.info('Checking ISO codes against %s' % iso_tables[0].name)
         iso = ISO(iso_tables[0])
     else:
         iso = None


### PR DESCRIPTION
Invalid ISO codes have been removed, but left or added as `hid` attributes of a languoid to allow matching with legacy infrastructure.