### PR TITLE
added two macrolanguage ISO codes

### DIFF
--- a/languoids/tree/indo1319/indo1320/indo1321/indo1325/konk1270/konk1270.ini
+++ b/languoids/tree/indo1319/indo1320/indo1321/indo1325/konk1270/konk1270.ini
@@ -3,6 +3,7 @@
 name = Konkanic
 glottocode = konk1270
 level = family
+iso639-3 = kok
 
 [classification]
 sub = **142255**

--- a/languoids/tree/indo1319/indo1320/iran1269/cent2317/cent2318/nort3177/laki1246/kurd1259/kurd1259.ini
+++ b/languoids/tree/indo1319/indo1320/iran1269/cent2317/cent2318/nort3177/laki1246/kurd1259/kurd1259.ini
@@ -3,6 +3,7 @@
 name = Kurdish
 glottocode = kurd1259
 level = family
+iso639-3 = kur
 
 [classification]
 sub = **300449**


### PR DESCRIPTION
The to languoids have the exact same set of ISO children as the ISO macrolanguages.