### PR TITLE
Glottolog needs bs4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ requires = [
     'termcolor',
     'newick',
     'markdown',
+    'bs4',
 ]
 
 setup(


### PR DESCRIPTION
..or running anything fails with:

```
ModuleNotFoundError: No module named 'bs4'
```

Note that bs4 is only used in two lines of code and it might be easier to inline the import within the specific functions to raise when they're run, rather than adding a 150kb dependency for two minor(?) commands.