### PR TITLE
Fix WALS code for yana1270

### DIFF
--- a/languoids/tree/atla1278/volt1241/nort3149/gura1261/cent2243/nort2777/bwam1248/otiv1239/nucl1743/gurm1247/west2461/nucl1748/nort3234/moss1237/moss1238/moss1236/yana1270/md.ini
+++ b/languoids/tree/atla1278/volt1241/nort3149/gura1261/cent2243/nort2777/bwam1248/otiv1239/nucl1743/gurm1247/west2461/nucl1748/nort3234/moss1237/moss1238/moss1236/yana1270/md.ini
@@ -2,14 +2,10 @@
 [core]
 name = Yana (Mossi)
 level = dialect
-macroareas = 
-	North America
-countries = 
-
-[identifier]
-wals = genus/yana
+macroareas =
+	Africa
+countries =
 
 [classification]
-familyrefs = 
+familyrefs =
 	**hh:hv:Campbell:1997**
-


### PR DESCRIPTION
The WALS genus yana was assigned to this languoid. yana1270 is a dialect of the African Atlantic-Congo language Mossi, while yana1271 is the American Yana language.