### PR TITLE
Remove misapplied identifiers

### DIFF
--- a/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/cent2260/grea1286/kela1261/tsin1240/vieu1234/nkut1239/bosh1243/saka1287/baii1247/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/cent2260/grea1286/kela1261/tsin1240/vieu1234/nkut1239/bosh1243/saka1287/baii1247/md.ini
@@ -2,10 +2,6 @@
 [core]
 name = Bai (Democratic Republic of Congo)
 level = dialect
-macroareas = 
+macroareas =
 	Africa
-countries = 
-
-[identifier]
-wals = genus/bai
-
+countries =

--- a/languoids/tree/atla1278/volt1241/nort3149/came1255/uban1244/sere1265/sere1262/sere1266/sere1263/baiv1238/baii1251/md.ini
+++ b/languoids/tree/atla1278/volt1241/nort3149/came1255/uban1244/sere1265/sere1262/sere1266/sere1263/baiv1238/baii1251/md.ini
@@ -6,33 +6,31 @@ level = language
 iso639-3 = bdj
 latitude = 7.57221
 longitude = 26.48246
-macroareas = 
+macroareas =
 	Africa
-countries = 
+countries =
 	Sudan (SD)
 status = Definitely endangered
 
 [sources]
-glottolog = 
+glottolog =
 
 [altnames]
-multitree = 
+multitree =
 	Bai
 	Bari
-lexvo = 
+lexvo =
 	Bai [en]
 
 [triggers]
-lgcode = 
+lgcode =
 	the AND belanda
 
 [identifier]
-wals = genus/bai
 multitree = bdj
 endangeredlanguages = 3896
 
 [classification]
 sub = **hh:h:BoydPasch:Sere-Ngbaka-Mba**
-subrefs = 
+subrefs =
 	**hh:h:BoydPasch:Sere-Ngbaka-Mba**
-


### PR DESCRIPTION
The WALS genus [Bai](http://wals.info/languoid/genus/bai) should only be applied to the Sino-Tibetan language cent2004. I removed it from two unrelated African languages.