### PR TITLE
Remove WALS identifier genus/bororo from boro1274

### DIFF
--- a/languoids/tree/atla1278/nort3146/nort3148/peul1234/fula1264/fula1269/nige1253/boro1274/md.ini
+++ b/languoids/tree/atla1278/nort3146/nort3148/peul1234/fula1264/fula1269/nige1253/boro1274/md.ini
@@ -2,10 +2,6 @@
 [core]
 name = Bororo (Atlantic Congo)
 level = dialect
-macroareas = 
+macroareas =
 	Africa
-countries = 
-
-[identifier]
-wals = genus/bororo
-
+countries =


### PR DESCRIPTION
The WASL genus [Bororoan](http://wals.info/languoid/genus/bororo#8/-15.808/301.913) is for the South American language boro1282. I removed it from the unrelated African language boro1274.