### PR TITLE
Remove incorrect identifier from mura1277

### DIFF
--- a/languoids/tree/afro1255/chad1250/bium1280/nort3156/marg1267/mand1472/wand1280/wand1281/wand1278/mura1277/md.ini
+++ b/languoids/tree/afro1255/chad1250/bium1280/nort3156/marg1267/mand1472/wand1280/wand1281/wand1278/mura1277/md.ini
@@ -2,10 +2,6 @@
 [core]
 name = Mura
 level = dialect
-macroareas = 
+macroareas =
 	Africa
-countries = 
-
-[identifier]
-wals = genus/mura
-
+countries =


### PR DESCRIPTION
The WALS identifier genus/mura is a South American genus that includes pira1253. mura1277 is an unrelated African language