### PR TITLE
Remove incorrect WALS identifiers

### DIFF
--- a/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/east2731/corr1234/mboz1235/mwik1240/fipa1240/fipa1238/kwaa1264/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/east2731/corr1234/mboz1235/mwik1240/fipa1240/fipa1238/kwaa1264/md.ini
@@ -2,10 +2,6 @@
 [core]
 name = Kwa (Fipa)
 level = dialect
-macroareas = 
+macroareas =
 	Africa
-countries = 
-
-[identifier]
-wals = genus/kwa
-
+countries =

--- a/languoids/tree/atla1278/volt1241/nort3149/gura1261/cent2243/waja1258/bikw1235/unun9903/kwaa1262/md.ini
+++ b/languoids/tree/atla1278/volt1241/nort3149/gura1261/cent2243/waja1258/bikw1235/unun9903/kwaa1262/md.ini
@@ -6,33 +6,28 @@ level = language
 iso639-3 = kwb
 latitude = 9.42222
 longitude = 11.4439
-macroareas = 
+macroareas =
 	Africa
-countries = 
+countries =
 	Nigeria (NG)
 
 [sources]
-glottolog = 
+glottolog =
 	**weball:5255**
 
 [altnames]
-multitree = 
+multitree =
 	Baa
 	Kwa
 	Kwah
-lexvo = 
+lexvo =
 	Kwa [en]
 
 [triggers]
-lgcode = 
+lgcode =
 	western AND begho
-
-[identifier]
-wals = genus/kwa
-multitree = kwb
 
 [classification]
 sub = **hh:hvld:Kleinewillinghofer:Adamawa**
-subrefs = 
+subrefs =
 	**hh:hvld:Kleinewillinghofer:Adamawa**
-

--- a/languoids/tree/atla1278/volt1241/nort3149/gura1261/cent2243/waja1258/bikw1235/unun9903/kwaa1262/nucl1372/md.ini
+++ b/languoids/tree/atla1278/volt1241/nort3149/gura1261/cent2243/waja1258/bikw1235/unun9903/kwaa1262/nucl1372/md.ini
@@ -2,10 +2,6 @@
 [core]
 name = Nuclear Kwa
 level = dialect
-macroareas = 
+macroareas =
 	Africa
-countries = 
-
-[identifier]
-wals = genus/kwa
-
+countries =


### PR DESCRIPTION
The WALS genus Kwa was incorrectly assigned to several dialects. The genus would correspond to http://glottolog.org/resource/languoid/id/kwav1236.