### PR TITLE
make info on retired ISO codes more complete

### DIFF
--- a/languoids/tree/afro1255/cush1243/cent2193/awng1244/md.ini
+++ b/languoids/tree/afro1255/cush1243/cent2193/awng1244/md.ini
@@ -77,3 +77,9 @@ sub = **hh:hv:Appleyard:Agaw:1984**
 subrefs = 
 	**hh:hv:Appleyard:Agaw:1984**
 
+[iso_retirement]
+change_request = 2007-044
+effective = 2008-01-14 
+supersedes = 
+	xuf
+

--- a/languoids/tree/afro1255/cush1243/sout3054/unun9872/aasa1238/md.ini
+++ b/languoids/tree/afro1255/cush1243/sout3054/unun9872/aasa1238/md.ini
@@ -59,3 +59,9 @@ subrefs =
 	**hh:hv:Tosco:Cushitic**
 	**hh:hv:Kiessling:South-East-Cushitic**
 
+[iso_retirement]
+change_request = 2014-042
+effective = 2015-01-12 
+supersedes = 
+	aam
+

--- a/languoids/tree/afro1255/semi1276/west2786/ethi1244/sout3078/tran1288/hara1270/silt1239/silt1240/md.ini
+++ b/languoids/tree/afro1255/semi1276/west2786/ethi1244/sout3078/tran1288/hara1270/silt1239/silt1240/md.ini
@@ -63,3 +63,9 @@ subrefs =
 	**hh:hv:Weninger:Ethio-Semitic**
 	**hh:hv:Voigt:North-South-Ethiopian**
 
+[iso_retirement]
+change_request = 2007-114
+effective = 2008-02-28 
+supersedes = 
+	xst
+

--- a/languoids/tree/afro1255/semi1276/west2786/ethi1244/sout3078/tran1288/hara1270/silt1239/wola1253/md.ini
+++ b/languoids/tree/afro1255/semi1276/west2786/ethi1244/sout3078/tran1288/hara1270/silt1239/wola1253/md.ini
@@ -39,3 +39,9 @@ subrefs =
 	**hh:hv:Weninger:Ethio-Semitic**
 	**hh:hv:Voigt:North-South-Ethiopian**
 
+[iso_retirement]
+change_request = 2007-114
+effective = 2008-02-28 
+supersedes = 
+	xst
+

--- a/languoids/tree/algi1248/algo1256/east2700/sout3237/mohe1244/narr1280/md.ini
+++ b/languoids/tree/algi1248/algo1256/east2700/sout3237/mohe1244/narr1280/md.ini
@@ -9,3 +9,9 @@ countries =
 status = Extinct
 hid = xnt
 
+[iso_retirement]
+change_request = 2009-013
+effective = 2010-01-18 
+supersedes = 
+	mof
+

--- a/languoids/tree/algi1248/algo1256/east2700/sout3237/mohe1244/pequ1242/md.ini
+++ b/languoids/tree/algi1248/algo1256/east2700/sout3237/mohe1244/pequ1242/md.ini
@@ -11,3 +11,9 @@ hid = xpq
 longitude = -72.0
 latitude = 41.55
 
+[iso_retirement]
+change_request = 2009-013
+effective = 2010-01-18 
+supersedes = 
+	mof
+

--- a/languoids/tree/araf1243/anda1283/md.ini
+++ b/languoids/tree/araf1243/anda1283/md.ini
@@ -38,3 +38,9 @@ sub = **hh:ew:Haberland:Alfendio**
 subrefs = 
 	**hh:ew:Haberland:Alfendio**
 
+[iso_retirement]
+change_request = 2007-026
+effective = 2008-01-14 
+supersedes = 
+	arf
+

--- a/languoids/tree/araf1243/nanu1240/md.ini
+++ b/languoids/tree/araf1243/nanu1240/md.ini
@@ -36,3 +36,9 @@ sub = **hh:ew:Haberland:Alfendio**
 subrefs = 
 	**hh:ew:Haberland:Alfendio**
 
+[iso_retirement]
+change_request = 2007-026
+effective = 2008-01-14 
+supersedes = 
+	arf
+

--- a/languoids/tree/araf1243/tape1242/md.ini
+++ b/languoids/tree/araf1243/tape1242/md.ini
@@ -42,3 +42,9 @@ sub = **hh:ew:Haberland:Alfendio**
 subrefs = 
 	**hh:ew:Haberland:Alfendio**
 
+[iso_retirement]
+change_request = 2007-026
+effective = 2008-01-14 
+supersedes = 
+	arf
+

--- a/languoids/tree/araw1281/nort2990/inla1264/japu1236/nucl1764/bani1258/bani1259/bani1255/md.ini
+++ b/languoids/tree/araw1281/nort2990/inla1264/japu1236/nucl1764/bani1258/bani1259/bani1255/md.ini
@@ -76,3 +76,9 @@ subrefs =
 	**hh:hvw:Ramirez:Arawak**
 	**hh:hv:Aikhenvald:North-Arawak**
 
+[iso_retirement]
+change_request = 2007-006
+effective = 2008-01-14 
+supersedes = 
+	cru
+

--- a/languoids/tree/araw1281/nort2990/inla1264/japu1236/nucl1764/bani1258/bani1259/curr1243/md.ini
+++ b/languoids/tree/araw1281/nort2990/inla1264/japu1236/nucl1764/bani1258/bani1259/curr1243/md.ini
@@ -65,3 +65,9 @@ subrefs =
 	**hh:hvw:Ramirez:Arawak**
 	**hh:hv:Aikhenvald:North-Arawak**
 
+[iso_retirement]
+change_request = 2007-004
+effective = 2008-01-14 
+supersedes = 
+	paj
+

--- a/languoids/tree/araw1282/madi1262/jama1261/md.ini
+++ b/languoids/tree/araw1282/madi1262/jama1261/md.ini
@@ -85,3 +85,10 @@ sub = **hh:hv:Dienst:Arawan**
 subrefs = 
 	**hh:hv:Dienst:Arawan**
 
+[iso_retirement]
+change_request = 2006-013
+effective = 2007-07-18 
+supersedes = 
+	bnh
+	jap
+

--- a/languoids/tree/arti1236/renn1236/md.ini
+++ b/languoids/tree/arti1236/renn1236/md.ini
@@ -25,3 +25,10 @@ lexvo =
 multitree = rsi
 endangeredlanguages = 5349
 
+[iso_retirement]
+change_request = 2016-002
+remedy = Retire
+code = rsi
+name = Rennellese Sign Language
+effective = 2017-01-31 
+

--- a/languoids/tree/atla1278/mela1257/bull1245/bull1246/nort3167/bomk1234/krim1238/md.ini
+++ b/languoids/tree/atla1278/mela1257/bull1245/bull1246/nort3167/bomk1234/krim1238/md.ini
@@ -59,3 +59,10 @@ lgcode =
 multitree = krm
 endangeredlanguages = 365
 
+[iso_retirement]
+change_request = 2016-015
+remedy = Merge
+code = krm
+name = Krim
+effective = 2017-01-31 
+

--- a/languoids/tree/atla1278/mela1257/bull1245/bull1246/nort3167/bomk1234/md.ini
+++ b/languoids/tree/atla1278/mela1257/bull1245/bull1246/nort3167/bomk1234/md.ini
@@ -19,3 +19,9 @@ subrefs =
 [identifier]
 endangeredlanguages = 363
 
+[iso_retirement]
+change_request = 2016-015
+effective = 2017-01-31 
+supersedes = 
+	krm
+

--- a/languoids/tree/atla1278/volt1241/benu1247/akpe1249/edoi1239/nort3182/cent2259/emai1241/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/akpe1249/edoi1239/nort3182/cent2259/emai1241/md.ini
@@ -72,3 +72,9 @@ sub = **hh:hvw:Elugbe:Edoid**
 subrefs = 
 	**hh:hvw:Elugbe:Edoid**
 
+[iso_retirement]
+change_request = 2014-043
+effective = 2015-01-12 
+supersedes = 
+	uok
+

--- a/languoids/tree/atla1278/volt1241/benu1247/akpe1249/edoi1239/nort3183/sout3171/okpa1238/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/akpe1249/edoi1239/nort3183/sout3171/okpa1238/md.ini
@@ -33,3 +33,9 @@ sub = **hh:hvw:Elugbe:Edoid**
 subrefs = 
 	**hh:hvw:Elugbe:Edoid**
 
+[iso_retirement]
+change_request = 2011-153
+effective = 2012-02-03 
+supersedes = 
+	ibi
+

--- a/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/jara1262/nagu1244/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/jara1262/nagu1244/md.ini
@@ -31,3 +31,9 @@ sub = **hh:hvw:MaddiesonWilliamson:Jarawan**
 subrefs = 
 	**hh:hvw:MaddiesonWilliamson:Jarawan**
 
+[iso_retirement]
+change_request = 2014-046
+effective = 2015-01-12 
+supersedes = 
+	nnx
+

--- a/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/abab1240/oldb1234/ngbe1239/extr1247/nyan1303/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/abab1240/oldb1234/ngbe1239/extr1247/nyan1303/md.ini
@@ -31,3 +31,9 @@ lexvo =
 [identifier]
 multitree = nyc
 
+[iso_retirement]
+change_request = 2014-051
+effective = 2015-01-12 
+supersedes = 
+	gti
+

--- a/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/east2731/nort3203/grea1289/east2750/nyan1318/nort3227/suba1238/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/east2731/nort3203/grea1289/east2750/nyan1318/nort3227/suba1238/md.ini
@@ -54,3 +54,9 @@ lgcode =
 multitree = sxb
 endangeredlanguages = 4789
 
+[iso_retirement]
+change_request = 2007-031
+effective = 2008-01-14 
+supersedes = 
+	suh
+

--- a/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/east2731/nort3203/grea1289/east2750/nyan1318/nort3227/suba1252/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/east2731/nort3203/grea1289/east2750/nyan1318/nort3227/suba1252/md.ini
@@ -37,3 +37,9 @@ subrefs =
 	**hh:hvw:Schoenbrun:Great-Lakes-Bantu**
 	**hh:hv:Schoenbrun:Great-Lakes-Bantu:1994**
 
+[iso_retirement]
+change_request = 2007-031
+effective = 2008-01-14 
+supersedes = 
+	suh
+

--- a/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/east2731/nort3203/grea1289/east2750/nyan1318/sout3201/ikiz1238/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/east2731/nort3203/grea1289/east2750/nyan1318/sout3201/ikiz1238/md.ini
@@ -46,3 +46,9 @@ subrefs =
 	**hh:hvw:Schoenbrun:Great-Lakes-Bantu**
 	**hh:hv:Schoenbrun:Great-Lakes-Bantu:1994**
 
+[iso_retirement]
+change_request = 2007-033
+effective = 2008-01-14 
+supersedes = 
+	szk
+

--- a/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/east2731/nort3203/nort3209/coas1317/miji1240/poko1261/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/east2731/nort3203/nort3209/coas1317/miji1240/poko1261/md.ini
@@ -93,3 +93,9 @@ sub = **hh:hv:Nurse:EBantu**
 subrefs = 
 	**hh:hv:Nurse:EBantu**
 
+[iso_retirement]
+change_request = 2007-170
+effective = 2008-01-14 
+supersedes = 
+	poj
+

--- a/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/mbam1252/west2826/mand1474/nyok1243/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/mbam1252/west2826/mand1474/nyok1243/md.ini
@@ -24,3 +24,9 @@ sub = **hh:hv:MousBreedveld:Bantu-A40-A60**
 subrefs = 
 	**hh:hv:MousBreedveld:Bantu-A40-A60**
 
+[iso_retirement]
+change_request = 2011-080
+effective = 2012-02-03 
+supersedes = 
+	baz
+

--- a/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/mbam1252/west2826/mand1474/tune1261/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/mbam1252/west2826/mand1474/tune1261/md.ini
@@ -37,3 +37,9 @@ sub = **hh:hv:MousBreedveld:Bantu-A40-A60**
 subrefs = 
 	**hh:hv:MousBreedveld:Bantu-A40-A60**
 
+[iso_retirement]
+change_request = 2011-080
+effective = 2012-02-03 
+supersedes = 
+	baz
+

--- a/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/wide1239/narr1282/mbam1249/nkaa1239/nkam1238/yamb1251/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/wide1239/narr1282/mbam1249/nkaa1239/nkam1238/yamb1251/md.ini
@@ -53,3 +53,9 @@ sub = **hh:hv:Eliasetal:Mbam-Nkam**
 subrefs = 
 	**hh:hv:Eliasetal:Mbam-Nkam**
 
+[iso_retirement]
+change_request = 2014-044
+effective = 2015-01-12 
+supersedes = 
+	kwq
+

--- a/languoids/tree/atla1278/volt1241/benu1247/benu1248/ahwa1235/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/benu1248/ahwa1235/md.ini
@@ -45,3 +45,10 @@ lgcode =
 [identifier]
 multitree = nfd
 
+[iso_retirement]
+change_request = 2008-017
+effective = 2009-01-26 
+supersedes = 
+	nfg
+	nfk
+

--- a/languoids/tree/atla1278/volt1241/benu1247/benu1248/benu1249/sout3163/izer1242/gana1270/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/benu1248/benu1249/sout3163/izer1242/gana1270/md.ini
@@ -33,3 +33,9 @@ sub = **hh:hv:Gerhardt:Plateau**
 subrefs = 
 	**hh:hv:Gerhardt:Plateau**
 
+[iso_retirement]
+change_request = 2007-147
+effective = 2008-01-14 
+supersedes = 
+	fiz
+

--- a/languoids/tree/atla1278/volt1241/benu1247/benu1248/benu1249/sout3163/izer1242/izer1241/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/benu1248/benu1249/sout3163/izer1242/izer1241/md.ini
@@ -52,3 +52,9 @@ sub = **hh:hv:Gerhardt:Plateau**
 subrefs = 
 	**hh:hv:Gerhardt:Plateau**
 
+[iso_retirement]
+change_request = 2007-147
+effective = 2008-01-14 
+supersedes = 
+	fiz
+

--- a/languoids/tree/atla1278/volt1241/benu1247/igbo1258/igbo1259/izie1238/ezaa1238/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/igbo1258/igbo1259/izie1238/ezaa1238/md.ini
@@ -16,3 +16,9 @@ multitree =
 [identifier]
 multitree = izi-eza
 
+[iso_retirement]
+change_request = 2012-078
+effective = 2013-01-23 
+supersedes = 
+	izi
+

--- a/languoids/tree/atla1278/volt1241/benu1247/igbo1258/igbo1259/izie1238/ikwo1238/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/igbo1258/igbo1259/izie1238/ikwo1238/md.ini
@@ -15,3 +15,9 @@ multitree =
 [identifier]
 multitree = izi-ikw
 
+[iso_retirement]
+change_request = 2012-078
+effective = 2013-01-23 
+supersedes = 
+	izi
+

--- a/languoids/tree/atla1278/volt1241/benu1247/igbo1258/igbo1259/izie1238/izii1239/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/igbo1258/igbo1259/izie1238/izii1239/md.ini
@@ -10,3 +10,9 @@ hid = izz
 longitude = 8.0
 latitude = 6.33
 
+[iso_retirement]
+change_request = 2012-078
+effective = 2013-01-23 
+supersedes = 
+	izi
+

--- a/languoids/tree/atla1278/volt1241/benu1247/igbo1258/igbo1259/izie1238/mgbo1238/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/igbo1258/igbo1259/izie1238/mgbo1238/md.ini
@@ -16,3 +16,9 @@ multitree =
 [identifier]
 multitree = izi-mgb
 
+[iso_retirement]
+change_request = 2012-078
+effective = 2013-01-23 
+supersedes = 
+	izi
+

--- a/languoids/tree/atla1278/volt1241/benu1247/kain1275/cent2242/kamb1317/kamb1319/east2739/tsuv1239/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/kain1275/cent2242/kamb1317/kamb1319/east2739/tsuv1239/md.ini
@@ -42,3 +42,9 @@ subrefs =
 	**hh:g:McGill:Cicipu**
 	**hh:hv:McGill:Kainji**
 
+[iso_retirement]
+change_request = 2014-040
+effective = 2015-01-12 
+supersedes = 
+	kxe
+

--- a/languoids/tree/atla1278/volt1241/nort3149/came1255/samb1322/mumu1249/yand1260/bali1284/yott1234/md.ini
+++ b/languoids/tree/atla1278/volt1241/nort3149/came1255/samb1322/mumu1249/yand1260/bali1284/yott1234/md.ini
@@ -30,3 +30,9 @@ sub = **hh:hvw:Blench:Yendang**
 subrefs = 
 	**hh:hvw:Blench:Yendang**
 
+[iso_retirement]
+change_request = 2011-150
+effective = 2012-02-03 
+supersedes = 
+	yen
+

--- a/languoids/tree/atla1278/volt1241/nort3149/came1255/samb1322/mumu1249/yand1260/waka1284/waka1285/yend1241/md.ini
+++ b/languoids/tree/atla1278/volt1241/nort3149/came1255/samb1322/mumu1249/yand1260/waka1284/waka1285/yend1241/md.ini
@@ -19,3 +19,9 @@ sub = **hh:hvw:Blench:Yendang**
 subrefs = 
 	**hh:hvw:Blench:Yendang**
 
+[iso_retirement]
+change_request = 2011-150
+effective = 2012-02-03 
+supersedes = 
+	yen
+

--- a/languoids/tree/atla1278/volt1241/nort3149/came1255/samb1322/samb1323/unun9905/duli1241/md.ini
+++ b/languoids/tree/atla1278/volt1241/nort3149/came1255/samb1322/samb1323/unun9905/duli1241/md.ini
@@ -30,3 +30,9 @@ lexvo =
 [identifier]
 multitree = duli;duz
 
+[iso_retirement]
+change_request = 2015-001
+effective = 2016-01-15 
+supersedes = 
+	guv
+

--- a/languoids/tree/atla1278/volt1241/nort3149/gbay1279/gbay1280/mbod1237/gbay1281/md.ini
+++ b/languoids/tree/atla1278/volt1241/nort3149/gbay1279/gbay1280/mbod1237/gbay1281/md.ini
@@ -38,3 +38,9 @@ subrefs =
 	**hh:hvphon:Monino:Proto-Gbaya**
 	**hh:hv:Monino:Gbaya-Manza-Ngbaka-NC**
 
+[iso_retirement]
+change_request = 2007-187
+effective = 2008-01-14 
+supersedes = 
+	mdo
+

--- a/languoids/tree/atla1278/volt1241/nort3149/gbay1279/gbay1282/gbay1284/sout2785/md.ini
+++ b/languoids/tree/atla1278/volt1241/nort3149/gbay1279/gbay1282/gbay1284/sout2785/md.ini
@@ -49,3 +49,9 @@ subrefs =
 	**hh:hvphon:Monino:Proto-Gbaya**
 	**hh:hv:Monino:Gbaya-Manza-Ngbaka-NC**
 
+[iso_retirement]
+change_request = 2007-187
+effective = 2008-01-14 
+supersedes = 
+	mdo
+

--- a/languoids/tree/aust1305/bahn1264/west2399/nucl1299/oyyy1238/jeng1241/md.ini
+++ b/languoids/tree/aust1305/bahn1264/west2399/nucl1299/oyyy1238/jeng1241/md.ini
@@ -33,3 +33,10 @@ lgcode =
 [identifier]
 multitree = jeg
 
+[iso_retirement]
+change_request = 2016-012
+remedy = Merge
+code = jeg
+name = Jeng
+effective = 2017-01-31 
+

--- a/languoids/tree/aust1305/bahn1264/west2399/nucl1299/oyyy1238/md.ini
+++ b/languoids/tree/aust1305/bahn1264/west2399/nucl1299/oyyy1238/md.ini
@@ -41,3 +41,10 @@ sub = **hh:hv:Sidwell:Austroasiatic**
 subrefs = 
 	**hh:hv:Sidwell:Austroasiatic**
 
+[iso_retirement]
+change_request = 2016-012
+effective = 2017-01-31 
+supersedes = 
+	jeg
+	skk
+

--- a/languoids/tree/aust1305/bahn1264/west2399/nucl1299/oyyy1238/sokk1239/md.ini
+++ b/languoids/tree/aust1305/bahn1264/west2399/nucl1299/oyyy1238/sokk1239/md.ini
@@ -31,3 +31,10 @@ lexvo =
 [identifier]
 multitree = skk
 
+[iso_retirement]
+change_request = 2016-012
+remedy = Merge
+code = skk
+name = Sok
+effective = 2017-01-31 
+

--- a/languoids/tree/aust1305/katu1271/west1492/brou1236/east2783/kata1264/md.ini
+++ b/languoids/tree/aust1305/katu1271/west1492/brou1236/east2783/kata1264/md.ini
@@ -33,3 +33,10 @@ sub = **hh:hv:Gehrmann:West-Katuic**:46-48
 subrefs = 
 	**hh:hv:Gehrmann:West-Katuic**
 
+[iso_retirement]
+change_request = 2016-021
+remedy = Split
+code = kgd
+name = Kataang
+effective = 2017-01-31 
+

--- a/languoids/tree/aust1305/katu1271/west1492/brou1236/east2783/kata1264/nort3270/md.ini
+++ b/languoids/tree/aust1305/katu1271/west1492/brou1236/east2783/kata1264/nort3270/md.ini
@@ -16,3 +16,9 @@ sub = **hh:hv:Gehrmann:West-Katuic**:46-48
 subrefs = 
 	**hh:hv:Gehrmann:West-Katuic**
 
+[iso_retirement]
+change_request = 2016-021
+effective = 2017-01-31 
+supersedes = 
+	kgd
+

--- a/languoids/tree/aust1305/katu1271/west1492/brou1236/east2783/kata1264/sout3251/md.ini
+++ b/languoids/tree/aust1305/katu1271/west1492/brou1236/east2783/kata1264/sout3251/md.ini
@@ -16,3 +16,9 @@ sub = **hh:hv:Gehrmann:West-Katuic**:46-48
 subrefs = 
 	**hh:hv:Gehrmann:West-Katuic**
 
+[iso_retirement]
+change_request = 2016-021
+effective = 2017-01-31 
+supersedes = 
+	kgd
+

--- a/languoids/tree/aust1305/mund1335/nort3151/kher1245/mund1336/homu1234/mund1320/md.ini
+++ b/languoids/tree/aust1305/mund1335/nort3151/kher1245/mund1336/homu1234/mund1320/md.ini
@@ -219,3 +219,9 @@ sub = **hh:d:Hoffmann:Mundarica**
 subrefs = 
 	**hh:d:Hoffmann:Mundarica**
 
+[iso_retirement]
+change_request = 2007-065
+effective = 2008-02-18 
+supersedes = 
+	muw
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/basa1291/grea1283/sout2919/mala1537/nort3196/cent2271/nort3281/nort3212/sout2920/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/basa1291/grea1283/sout2919/mala1537/nort3196/cent2271/nort3281/nort3212/sout2920/md.ini
@@ -27,3 +27,9 @@ sub = **hh:hv:Servaetal:Malagasy**
 subrefs = 
 	**hh:hv:Servaetal:Malagasy**
 
+[iso_retirement]
+change_request = 2010-035
+effective = 2011-05-18 
+supersedes = 
+	bjq
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/basa1291/grea1283/sout2919/mala1537/nort3196/cent2271/tesa1236/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/basa1291/grea1283/sout2919/mala1537/nort3196/cent2271/tesa1236/md.ini
@@ -25,3 +25,9 @@ sub = **hh:hv:Servaetal:Malagasy**
 subrefs = 
 	**hh:hv:Servaetal:Malagasy**
 
+[iso_retirement]
+change_request = 2010-035
+effective = 2011-05-18 
+supersedes = 
+	bjq
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/basa1291/grea1283/sout2921/ngaj1237/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/basa1291/grea1283/sout2921/ngaj1237/md.ini
@@ -67,3 +67,10 @@ subrefs =
 	**hh:hvw:Smith:Borneo**
 	**hh:hv:Blust:NBorneo**
 
+[iso_retirement]
+change_request = 2007-184
+effective = 2008-01-14 
+supersedes = 
+	kxg
+	xah
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cele1242/east2488/salu1251/west2571/salu1252/batu1263/batu1260/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cele1242/east2488/salu1251/west2571/salu1252/batu1263/batu1260/md.ini
@@ -34,3 +34,9 @@ sub = **hh:hvw:MeadPasanda:Saluan-Batui**
 subrefs = 
 	**hh:hvw:MeadPasanda:Saluan-Batui**
 
+[iso_retirement]
+change_request = 2007-199
+effective = 2008-01-14 
+supersedes = 
+	bcx
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cele1242/east2488/salu1251/west2571/salu1252/batu1263/salu1253/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cele1242/east2488/salu1251/west2571/salu1252/batu1263/salu1253/md.ini
@@ -38,3 +38,9 @@ sub = **hh:hvw:MeadPasanda:Saluan-Batui**
 subrefs = 
 	**hh:hvw:MeadPasanda:Saluan-Batui**
 
+[iso_retirement]
+change_request = 2007-118
+effective = 2008-01-14 
+supersedes = 
+	slb
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cele1242/kail1255/kail1253/nort2898/pamo1251/pamo1252/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cele1242/kail1255/kail1253/nort2898/pamo1251/pamo1252/md.ini
@@ -38,3 +38,9 @@ sub = **hh:hv:vandenBerg:Wolio**
 subrefs = 
 	**hh:hv:vandenBerg:Wolio**
 
+[iso_retirement]
+change_request = 2007-199
+effective = 2008-01-14 
+supersedes = 
+	bcx
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cent2237/cent2245/cent2254/east2466/nunu1252/piru1243/west2843/hoam1238/west2853/luhu1243/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cent2237/cent2245/cent2254/east2466/nunu1252/piru1243/west2843/hoam1238/west2853/luhu1243/md.ini
@@ -33,3 +33,12 @@ sub = **hh:hvw:Collins:CMaluku**
 subrefs = 
 	**hh:hvw:Collins:CMaluku**
 
+[iso_retirement]
+change_request = 2012-096
+remedy = Merge
+code = lcq
+name = Luhu
+effective = 2013-01-23 
+supersedes = 
+	ppr
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cent2237/cent2245/cent2254/east2466/nunu1252/thre1238/amal1243/yala1266/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cent2237/cent2245/cent2254/east2466/nunu1252/thre1238/amal1243/yala1266/md.ini
@@ -34,3 +34,9 @@ sub = **hh:hvw:Collins:CMaluku**:34-60
 subrefs = 
 	**hh:hvw:Collins:CMaluku**
 
+[iso_retirement]
+change_request = 2011-086
+effective = 2012-02-03 
+supersedes = 
+	hrr
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cent2237/cent2245/cent2254/east2466/nunu1252/thre1238/nort2864/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cent2237/cent2245/cent2254/east2466/nunu1252/thre1238/nort2864/md.ini
@@ -29,3 +29,9 @@ sub = **hh:hvw:Collins:CMaluku**:34-60
 subrefs = 
 	**hh:hvw:Collins:CMaluku**
 
+[iso_retirement]
+change_request = 2011-083
+effective = 2012-02-03 
+supersedes = 
+	tlw
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cent2237/cent2245/timo1259/nort3194/galo1243/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cent2237/cent2245/timo1259/nort3194/galo1243/md.ini
@@ -35,3 +35,9 @@ sub = **hh:hvw:Hull:Timor:Austronesian**
 subrefs = 
 	**hh:hvw:Hull:Timor:Austronesian**
 
+[iso_retirement]
+change_request = 2012-151
+effective = 2013-01-23 
+supersedes = 
+	ilw
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/nort3195/nort3205/torr1262/leme1240/leme1238/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/nort3195/nort3205/torr1262/leme1240/leme1238/md.ini
@@ -43,3 +43,9 @@ sub = **hh:hv:KalyanFrancois:Freeing**
 subrefs = 
 	**hh:hv:KalyanFrancois:Freeing**
 
+[iso_retirement]
+change_request = 2008-069
+effective = 2009-01-16 
+supersedes = 
+	vlr
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/nort3195/nort3205/torr1262/leme1240/vera1241/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/nort3195/nort3205/torr1262/leme1240/vera1241/md.ini
@@ -30,3 +30,9 @@ sub = **hh:hv:KalyanFrancois:Freeing**
 subrefs = 
 	**hh:hv:KalyanFrancois:Freeing**
 
+[iso_retirement]
+change_request = 2008-069
+effective = 2009-01-16 
+supersedes = 
+	vlr
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/sout3173/newc1243/sout3189/tiri1258/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/sout3173/newc1243/sout3189/tiri1258/md.ini
@@ -46,3 +46,9 @@ sub = **hh:hbld:Haudricourt:New-Caledonia-Loyalty**
 subrefs = 
 	**hh:hbld:Haudricourt:New-Caledonia-Loyalty**
 
+[iso_retirement]
+change_request = 2012-131
+effective = 2013-01-23 
+supersedes = 
+	meg
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/temo1244/reef1242/natu1250/nalo1235/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/temo1244/reef1242/natu1250/nalo1235/md.ini
@@ -40,3 +40,9 @@ subrefs =
 	**hh:hv:Lincoln:Reef-Santa**
 	**hh:hv:Wurm:EPapuan**
 
+[iso_retirement]
+change_request = 2008-070
+effective = 2009-01-16 
+supersedes = 
+	stc
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/temo1244/reef1242/natu1250/natu1246/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/temo1244/reef1242/natu1250/natu1246/md.ini
@@ -42,3 +42,9 @@ subrefs =
 	**hh:hv:Lincoln:Reef-Santa**
 	**hh:hv:Wurm:EPapuan**
 
+[iso_retirement]
+change_request = 2008-070
+effective = 2009-01-16 
+supersedes = 
+	stc
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/west2818/meso1253/newi1242/stge1234/tang1348/make1251/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/west2818/meso1253/newi1242/stge1234/tang1348/make1251/md.ini
@@ -15,3 +15,9 @@ multitree =
 [identifier]
 multitree = tgg-mak
 
+[iso_retirement]
+change_request = 2012-141
+effective = 2013-01-23 
+supersedes = 
+	tgg
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/west2818/meso1253/newi1242/stge1234/tang1348/niwe1235/anir1237/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/west2818/meso1253/newi1242/stge1234/tang1348/niwe1235/anir1237/md.ini
@@ -16,3 +16,9 @@ multitree =
 [identifier]
 multitree = tgg-ani
 
+[iso_retirement]
+change_request = 2012-141
+effective = 2013-01-23 
+supersedes = 
+	tgg
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/west2818/meso1253/newi1242/stge1234/tang1348/niwe1235/niwe1234/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/west2818/meso1253/newi1242/stge1234/tang1348/niwe1235/niwe1234/md.ini
@@ -11,3 +11,9 @@ macroareas =
 longitude = 153.2
 latitude = -3.47
 
+[iso_retirement]
+change_request = 2012-141
+effective = 2013-01-23 
+supersedes = 
+	tgg
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/west2818/nort3206/huon1245/mark1257/uppe1423/adze1240/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/west2818/nort3206/huon1245/mark1257/uppe1423/adze1240/md.ini
@@ -64,3 +64,9 @@ sub = **hh:hvphon:Holzknecht:Markham**
 subrefs = 
 	**hh:hvphon:Holzknecht:Markham**
 
+[iso_retirement]
+change_request = 2007-186
+effective = 2008-01-14 
+supersedes = 
+	azr
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/west2818/nort3206/huon1245/mark1257/uppe1423/moun1250/sara1323/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/west2818/nort3206/huon1245/mark1257/uppe1423/moun1250/sara1323/md.ini
@@ -33,3 +33,9 @@ sub = **hh:hvphon:Holzknecht:Markham**
 subrefs = 
 	**hh:hvphon:Holzknecht:Markham**
 
+[iso_retirement]
+change_request = 2007-186
+effective = 2008-01-14 
+supersedes = 
+	azr
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/west2818/nort3206/huon1245/mark1257/uppe1423/moun1250/suku1264/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/west2818/nort3206/huon1245/mark1257/uppe1423/moun1250/suku1264/md.ini
@@ -32,3 +32,9 @@ sub = **hh:hvphon:Holzknecht:Markham**
 subrefs = 
 	**hh:hvphon:Holzknecht:Markham**
 
+[iso_retirement]
+change_request = 2007-186
+effective = 2008-01-14 
+supersedes = 
+	azr
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/west2818/nort3206/sarm1241/sarm1242/kapt1235/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/west2818/nort3206/sarm1241/sarm1242/kapt1235/md.ini
@@ -30,3 +30,9 @@ sub = **hh:hv:Ross:WMelanesia**:120-132
 subrefs = 
 	**hh:hv:Ross:WMelanesia**
 
+[iso_retirement]
+change_request = 2007-231
+effective = 2008-01-14 
+supersedes = 
+	suf
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/west2818/nort3206/sarm1241/sarm1242/tarp1240/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/west2818/nort3206/sarm1241/sarm1242/tarp1240/md.ini
@@ -31,3 +31,9 @@ sub = **hh:hv:Ross:WMelanesia**:120-132
 subrefs = 
 	**hh:hv:Ross:WMelanesia**
 
+[iso_retirement]
+change_request = 2007-231
+effective = 2008-01-14 
+supersedes = 
+	suf
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/west2818/papu1253/nucl1744/suau1243/waga1268/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/cent2237/east2712/ocea1241/west2818/papu1253/nucl1744/suau1243/waga1268/md.ini
@@ -19,3 +19,9 @@ sub = **hh:hv:Ross:WMelanesia**:190-212
 subrefs = 
 	**hh:hv:Ross:WMelanesia**
 
+[iso_retirement]
+change_request = 2009-045
+effective = 2010-01-18 
+supersedes = 
+	wgw
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/grea1284/cent2246/biko1240/inla1266/alba1269/buhi1243/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/grea1284/cent2246/biko1240/inla1266/alba1269/buhi1243/md.ini
@@ -10,3 +10,9 @@ hid = ubl
 longitude = 123.5
 latitude = 13.17
 
+[iso_retirement]
+change_request = 2009-078
+effective = 2010-01-18 
+supersedes = 
+	bhk
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/grea1284/cent2246/biko1240/inla1266/alba1269/libo1242/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/grea1284/cent2246/biko1240/inla1266/alba1269/libo1242/md.ini
@@ -10,3 +10,9 @@ hid = lbl
 longitude = 123.5
 latitude = 13.17
 
+[iso_retirement]
+change_request = 2009-078
+effective = 2010-01-18 
+supersedes = 
+	bhk
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/grea1284/cent2246/bisa1268/sout3175/suri1274/suri1273/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/grea1284/cent2246/bisa1268/sout3175/suri1274/suri1273/md.ini
@@ -19,3 +19,9 @@ sub = **hh:hv:Zorc:Bisayan**
 subrefs = 
 	**hh:hv:Zorc:Bisayan**
 
+[iso_retirement]
+change_request = 2009-087
+effective = 2010-01-18 
+supersedes = 
+	sul
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/grea1284/cent2246/bisa1268/sout3175/suri1274/tand1258/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/grea1284/cent2246/bisa1268/sout3175/suri1274/tand1258/md.ini
@@ -17,3 +17,9 @@ sub = **hh:hv:Zorc:Bisayan**
 subrefs = 
 	**hh:hv:Zorc:Bisayan**
 
+[iso_retirement]
+change_request = 2009-087
+effective = 2010-01-18 
+supersedes = 
+	sul
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/grea1284/cent2246/mans1261/east2477/kara1489/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/grea1284/cent2246/mans1261/east2477/kara1489/md.ini
@@ -35,3 +35,10 @@ lexvo =
 [identifier]
 multitree = mry
 
+[iso_retirement]
+change_request = 2009-068
+effective = 2010-01-18 
+supersedes = 
+	mst
+	myt
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/grea1284/dana1253/iran1262/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/grea1284/dana1253/iran1262/md.ini
@@ -46,3 +46,10 @@ sub = **hh:hv:Allison:Danaw**
 subrefs = 
 	**hh:hv:Allison:Danaw**
 
+[iso_retirement]
+change_request = 2015-067
+remedy = Split
+code = ill
+name = Iranun
+effective = 2016-01-15 
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/lamp1241/kome1238/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/lamp1241/kome1238/md.ini
@@ -39,3 +39,9 @@ sub = **hh:hv:Anderbeck:Proto-Lampungic**
 subrefs = 
 	**hh:hv:Anderbeck:Proto-Lampungic**
 
+[iso_retirement]
+change_request = 2007-195
+effective = 2008-01-14 
+supersedes = 
+	vky
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/lamp1241/lamp1243/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/lamp1241/lamp1243/md.ini
@@ -73,3 +73,13 @@ sub = **hh:hv:Anderbeck:Proto-Lampungic**
 subrefs = 
 	**hh:hv:Anderbeck:Proto-Lampungic**
 
+[iso_retirement]
+change_request = 2007-142
+effective = 2008-01-14 
+supersedes = 
+	krq
+	pec
+	pun
+	rae
+	suu
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/mala1536/nort3170/mala1538/nucl1733/indo1326/musi1241/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/mala1536/nort3170/mala1538/nucl1733/indo1326/musi1241/md.ini
@@ -37,3 +37,12 @@ lgcode =
 [identifier]
 multitree = mui
 
+[iso_retirement]
+change_request = 2007-182
+effective = 2008-01-14 
+supersedes = 
+	lmt
+	pen
+	plm
+	rws
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/mala1536/nort3170/mala1538/nucl1733/indo1326/stan1306/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/mala1536/nort3170/mala1538/nucl1733/indo1326/stan1306/md.ini
@@ -98,3 +98,9 @@ sub = **hh:hv:Adelaar:Malayic:Structural**
 subrefs = 
 	**hh:hv:Adelaar:Malayic:Structural**
 
+[iso_retirement]
+change_request = 2007-183
+effective = 2008-02-18 
+supersedes = 
+	mly
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/mala1536/nort3170/mala1538/nucl1733/midd1346/cent2053/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/mala1536/nort3170/mala1538/nucl1733/midd1346/cent2053/md.ini
@@ -44,3 +44,14 @@ lgcode =
 [identifier]
 multitree = pse
 
+[iso_retirement]
+change_request = 2007-179
+effective = 2008-01-14 
+supersedes = 
+	bke
+	eni
+	lnt
+	ogn
+	sdd
+	srj
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/mala1536/nort3170/mala1538/nucl1733/midd1346/coll1240/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/mala1536/nort3170/mala1538/nucl1733/midd1346/coll1240/md.ini
@@ -44,3 +44,9 @@ lgcode =
 [identifier]
 multitree = liw;cua-kol
 
+[iso_retirement]
+change_request = 2007-196
+effective = 2008-01-14 
+supersedes = 
+	sdi
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/mala1536/nort3170/mala1538/nucl1733/midd1346/haji1235/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/mala1536/nort3170/mala1538/nucl1733/midd1346/haji1235/md.ini
@@ -120,3 +120,9 @@ lgcode =
 [identifier]
 multitree = hji
 
+[iso_retirement]
+change_request = 2007-183
+effective = 2008-02-18 
+supersedes = 
+	mly
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/mala1536/nort3170/mala1538/nucl1733/mina1280/mina1268/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/mala1536/nort3170/mala1538/nucl1733/mina1280/mina1268/md.ini
@@ -130,3 +130,9 @@ sub = **hh:v:Kurniatietal:Tapan**
 subrefs = 
 	**hh:v:Kurniatietal:Tapan**
 
+[iso_retirement]
+change_request = 2007-181
+effective = 2008-01-14 
+supersedes = 
+	vmo
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/mala1536/nort3170/mala1538/nucl1733/sing1270/mala1479/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/mala1536/nort3170/mala1538/nucl1733/sing1270/mala1479/md.ini
@@ -93,3 +93,9 @@ sub = **hh:hv:Ross:Malayic**
 subrefs = 
 	**hh:hv:Ross:Malayic**
 
+[iso_retirement]
+change_request = 2007-183
+effective = 2008-02-18 
+supersedes = 
+	mly
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/mala1536/nort3170/mala1538/vehi1234/east2743/papu1250/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/mala1536/nort3170/mala1538/vehi1234/east2743/papu1250/md.ini
@@ -44,3 +44,9 @@ sub = **hh:hs:Paauw:Malay**
 subrefs = 
 	**hh:hs:Paauw:Malay**
 
+[iso_retirement]
+change_request = 2007-183
+effective = 2008-02-18 
+supersedes = 
+	mly
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/mala1536/nort3170/mala1538/west2821/kend1254/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/mala1536/nort3170/mala1538/west2821/kend1254/md.ini
@@ -59,3 +59,10 @@ subrefs =
 	**hh:std:Adelaar:Salako**
 	**hh:v:Adelaar:Belangin**
 
+[iso_retirement]
+change_request = 2007-261
+effective = 2008-01-14 
+supersedes = 
+	ahe
+	skl
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/nort3238/meso1254/sout3211/cent2296/nort3240/kali1310/kali1311/cent2282/sout3203/sout3207/lowe1412/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/nort3238/meso1254/sout3211/cent2296/nort3240/kali1310/kali1311/cent2282/sout3203/sout3207/lowe1412/md.ini
@@ -38,3 +38,9 @@ sub = **hh:hv:Himes:Kalinga-Itneg**
 subrefs = 
 	**hh:hv:Himes:Kalinga-Itneg**
 
+[iso_retirement]
+change_request = 2011-079
+effective = 2012-02-03 
+supersedes = 
+	kgh
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/nort3238/meso1254/sout3211/sout2907/west2550/nucl1542/kall1244/ahin1234/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/nort3238/meso1254/sout3211/sout2907/west2550/nucl1542/kall1244/ahin1234/md.ini
@@ -16,3 +16,9 @@ sub = **hh:hv:Himes:Southern-Cordilleran**
 subrefs = 
 	**hh:hv:Himes:Southern-Cordilleran**
 
+[iso_retirement]
+change_request = 2015-061
+effective = 2016-01-15 
+supersedes = 
+	tne
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/nort3238/meso1254/sout3211/sout2907/west2550/nucl1542/kall1244/ahin1234/tino1235/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/nort3238/meso1254/sout3211/sout2907/west2550/nucl1542/kall1244/ahin1234/tino1235/md.ini
@@ -25,3 +25,10 @@ lexvo =
 [identifier]
 multitree = tne
 
+[iso_retirement]
+change_request = 2015-061
+remedy = Merge
+code = tne
+name = Tinoc Kallahan
+effective = 2016-01-15 
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/nort3238/nort3187/nucl1755/para1320/agta1234/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/nort3238/nort3187/nucl1755/para1320/agta1234/md.ini
@@ -22,3 +22,9 @@ sub = **hh:hv:RobinsonLobel:Northeastern-Luzon**
 subrefs = 
 	**hh:hv:RobinsonLobel:Northeastern-Luzon**
 
+[iso_retirement]
+change_request = 2009-086
+effective = 2010-01-18 
+supersedes = 
+	agp
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/nort3238/nort3187/nucl1755/para1320/para1306/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/nort3238/nort3187/nucl1755/para1320/para1306/md.ini
@@ -19,3 +19,9 @@ sub = **hh:hv:RobinsonLobel:Northeastern-Luzon**
 subrefs = 
 	**hh:hv:RobinsonLobel:Northeastern-Luzon**
 
+[iso_retirement]
+change_request = 2009-086
+effective = 2010-01-18 
+supersedes = 
+	agp
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/nort3253/nort3171/bera1263/bera1264/cent2097/cent2098/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/nort3253/nort3171/bera1263/bera1264/cent2097/cent2098/md.ini
@@ -32,3 +32,9 @@ sub = **hh:hvw:Smith:Borneo**:235-258
 subrefs = 
 	**hh:hvw:Smith:Borneo**
 
+[iso_retirement]
+change_request = 2007-200
+effective = 2008-01-14 
+supersedes = 
+	lod
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/nort3253/nort3171/bera1263/bera1264/cent2097/east2486/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/nort3253/nort3171/bera1263/bera1264/cent2097/east2486/md.ini
@@ -30,3 +30,9 @@ sub = **hh:hvw:Smith:Borneo**:235-258
 subrefs = 
 	**hh:hvw:Smith:Borneo**
 
+[iso_retirement]
+change_request = 2007-200
+effective = 2008-01-14 
+supersedes = 
+	lod
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/nort3253/nort3171/bera1263/bera1264/west2564/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/nort3253/nort3171/bera1263/bera1264/west2564/md.ini
@@ -34,3 +34,9 @@ sub = **hh:hvw:Smith:Borneo**:235-258
 subrefs = 
 	**hh:hvw:Smith:Borneo**
 
+[iso_retirement]
+change_request = 2007-200
+effective = 2008-01-14 
+supersedes = 
+	lod
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/nort3253/nort3171/keny1280/high1288/main1275/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/nort3253/nort3171/keny1280/high1288/main1275/md.ini
@@ -53,3 +53,10 @@ subrefs =
 	**hh:hvw:Smith:Kenyah-Kayanic**
 	**hh:hv:Sellato:Kenyah-Putuk**
 
+[iso_retirement]
+change_request = 2007-245
+effective = 2008-01-14 
+supersedes = 
+	boc
+	mqd
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/nort3253/sara1342/mela1255/sibu1259/kano1244/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/nort3253/sara1342/mela1255/sibu1259/kano1244/md.ini
@@ -32,3 +32,9 @@ subrefs =
 	**hh:hv:Kroeger:Sarawak**
 	**hh:hvw:Smith:Borneo**
 
+[iso_retirement]
+change_request = 2007-235
+effective = 2008-01-14 
+supersedes = 
+	tnj
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/nort3253/sout3154/grea1293/bisa1270/brun1245/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/nort3253/sout3154/grea1293/bisa1270/brun1245/md.ini
@@ -49,3 +49,10 @@ subrefs =
 	**hh:hv:Lobel:Southwest-Sabah**
 sub = **hh:hv:Lobel:Southwest-Sabah**
 
+[iso_retirement]
+change_request = 2007-206
+effective = 2008-01-14 
+supersedes = 
+	bsd
+	ttx
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/nort3253/sout3154/grea1293/dusu1277/kada1292/cent2100/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/nort3253/sout3154/grea1293/dusu1277/kada1292/cent2100/md.ini
@@ -45,3 +45,12 @@ sub = **hh:hdialsoc:BankerBanker:Kadazan-Dusun**
 subrefs = 
 	**hh:hdialsoc:BankerBanker:Kadazan-Dusun**
 
+[iso_retirement]
+change_request = 2015-060
+effective = 2016-01-15 
+supersedes = 
+	ktr
+	kzj
+	kzt
+	tdu
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/nort3253/sout3154/grea1293/dusu1277/kada1292/coas1294/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/nort3253/sout3154/grea1293/dusu1277/kada1292/coas1294/md.ini
@@ -162,3 +162,10 @@ sub = **hh:hdialsoc:BankerBanker:Kadazan-Dusun**
 subrefs = 
 	**hh:hdialsoc:BankerBanker:Kadazan-Dusun**
 
+[iso_retirement]
+change_request = 2015-060
+remedy = Merge
+code = kzj
+name = Coastal Kadazan
+effective = 2016-01-15 
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/nort3253/sout3154/grea1293/dusu1277/kada1292/sugu1244/kota1278/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/nort3253/sout3154/grea1293/dusu1277/kada1292/sugu1244/kota1278/md.ini
@@ -34,3 +34,10 @@ lgcode =
 [identifier]
 multitree = ktr
 
+[iso_retirement]
+change_request = 2015-060
+remedy = Merge
+code = ktr
+name = Kota Marudu Tinagas
+effective = 2016-01-15 
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/nort3253/sout3154/grea1293/dusu1277/kada1292/sugu1244/tamb1254/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/nort3253/sout3154/grea1293/dusu1277/kada1292/sugu1244/tamb1254/md.ini
@@ -34,3 +34,10 @@ sub = **hh:hdialsoc:BankerBanker:Kadazan-Dusun**
 subrefs = 
 	**hh:hdialsoc:BankerBanker:Kadazan-Dusun**
 
+[iso_retirement]
+change_request = 2015-060
+remedy = Merge
+code = kzt
+name = Tambunan Dusun
+effective = 2016-01-15 
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/nort3253/sout3154/grea1293/dusu1277/kada1292/temp1235/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/nort3253/sout3154/grea1293/dusu1277/kada1292/temp1235/md.ini
@@ -39,3 +39,10 @@ sub = **hh:hdialsoc:BankerBanker:Kadazan-Dusun**
 subrefs = 
 	**hh:hdialsoc:BankerBanker:Kadazan-Dusun**
 
+[iso_retirement]
+change_request = 2015-060
+remedy = Merge
+code = tdu
+name = Tempasuk Dusun
+effective = 2016-01-15 
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/nort3253/sout3154/grea1294/muru1275/nort3186/suma1273/tidu1238/tidu1239/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/nort3253/sout3154/grea1294/muru1275/nort3186/suma1273/tidu1238/tidu1239/md.ini
@@ -18,3 +18,10 @@ subrefs =
 	**hh:ld:Moody:Tidong**
 	**hh:h:Lobel:Philippine**
 
+[iso_retirement]
+change_request = 2015-058
+remedy = Split
+code = tid
+name = Tidong
+effective = 2016-01-15 
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/nort3253/sout3154/grea1294/muru1275/nort3186/suma1273/tidu1238/tidu1239/nort3262/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/nort3253/sout3154/grea1294/muru1275/nort3186/suma1273/tidu1238/tidu1239/nort3262/md.ini
@@ -15,3 +15,9 @@ subrefs =
 	**hh:ld:Moody:Tidong**
 	**hh:h:Lobel:Philippine**
 
+[iso_retirement]
+change_request = 2015-058
+effective = 2016-01-15 
+supersedes = 
+	tid
+

--- a/languoids/tree/aust1307/nucl1752/mala1545/nort3253/sout3154/grea1294/muru1275/nort3186/suma1273/tidu1238/tidu1239/sout3241/md.ini
+++ b/languoids/tree/aust1307/nucl1752/mala1545/nort3253/sout3154/grea1294/muru1275/nort3186/suma1273/tidu1238/tidu1239/sout3241/md.ini
@@ -17,3 +17,9 @@ subrefs =
 	**hh:ld:Moody:Tidong**
 	**hh:h:Lobel:Philippine**
 
+[iso_retirement]
+change_request = 2015-058
+effective = 2016-01-15 
+supersedes = 
+	tid
+

--- a/languoids/tree/basq1248/md.ini
+++ b/languoids/tree/basq1248/md.ini
@@ -249,3 +249,9 @@ languagelandscape = http://languagelandscape.org/language/Euskara
 familyrefs = 
 	**hh:v:Trask:Basque**
 
+[iso_retirement]
+change_request = 2006-119
+effective = 2007-08-10 
+supersedes = 
+	bqe
+

--- a/languoids/tree/book1242/adap1234/md.ini
+++ b/languoids/tree/book1242/adap1234/md.ini
@@ -23,3 +23,10 @@ isohid = adp
 comment_type = Spurious
 ethnologue_versions = E16/E17
 
+[iso_retirement]
+change_request = 2014-049
+remedy = Merge
+code = adp
+name = Adap
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/aghu1256/md.ini
+++ b/languoids/tree/book1242/aghu1256/md.ini
@@ -22,3 +22,9 @@ ethnologue_versions = E17/E18/E19
 [identifier]
 endangeredlanguages = 6661
 
+[iso_retirement]
+change_request = 2012-138
+effective = 2013-01-23 
+supersedes = 
+	ggr
+

--- a/languoids/tree/book1242/aram1252/md.ini
+++ b/languoids/tree/book1242/aram1252/md.ini
@@ -25,3 +25,10 @@ isohid = aam
 comment_type = Spurious
 ethnologue_versions = E16/E17
 
+[iso_retirement]
+change_request = 2014-042
+remedy = Merge
+code = aam
+name = Aramanik
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/baga1276/md.ini
+++ b/languoids/tree/book1242/baga1276/md.ini
@@ -49,3 +49,10 @@ isohid = bgm
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-065
+remedy = Retire
+code = bgm
+name = Baga Mboteni
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/bemb1258/md.ini
+++ b/languoids/tree/book1242/bemb1258/md.ini
@@ -58,3 +58,10 @@ isohid = bmy
 comment_type = Spurious
 ethnologue_versions = E16/E17
 
+[iso_retirement]
+change_request = 2014-031
+remedy = Retire
+code = bmy
+name = Bemba (Democratic Republic of Congo)
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/bhat1237/md.ini
+++ b/languoids/tree/book1242/bhat1237/md.ini
@@ -27,3 +27,10 @@ isohid = btl
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-047
+remedy = Retire
+code = btl
+name = Bhatola
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/born1252/md.ini
+++ b/languoids/tree/book1242/born1252/md.ini
@@ -42,3 +42,10 @@ isohid = bxx
 comment_type = Spurious
 ethnologue_versions = E16/E17
 
+[iso_retirement]
+change_request = 2014-032
+remedy = Retire
+code = bxx
+name = Borna (Democratic Republic of Congo)
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/buya1245/md.ini
+++ b/languoids/tree/book1242/buya1245/md.ini
@@ -36,3 +36,10 @@ isohid = byy
 comment_type = Spurious
 ethnologue_versions = E16/E17
 
+[iso_retirement]
+change_request = 2014-033
+remedy = Retire
+code = byy
+name = Buya
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/cagu1236/md.ini
+++ b/languoids/tree/book1242/cagu1236/md.ini
@@ -32,3 +32,10 @@ isohid = cbh
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-034
+remedy = Retire
+code = cbh
+name = Cagua
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/chil1283/md.ini
+++ b/languoids/tree/book1242/chil1283/md.ini
@@ -20,3 +20,10 @@ isohid = cqu
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-024
+remedy = Merge
+code = cqu
+name = Chilean Quechua
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/chip1236/md.ini
+++ b/languoids/tree/book1242/chip1236/md.ini
@@ -31,3 +31,10 @@ isohid = cbe
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-036
+remedy = Retire
+code = cbe
+name = Chipiajes
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/chua1256/md.ini
+++ b/languoids/tree/book1242/chua1256/md.ini
@@ -25,3 +25,9 @@ isohid = cqd
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18/E19
 
+[iso_retirement]
+change_request = 2007-188
+effective = 2008-01-14 
+supersedes = 
+	blu
+

--- a/languoids/tree/book1242/coxi1236/md.ini
+++ b/languoids/tree/book1242/coxi1236/md.ini
@@ -37,3 +37,10 @@ isohid = kox
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-035
+remedy = Retire
+code = kox
+name = Coxima
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/coya1241/md.ini
+++ b/languoids/tree/book1242/coya1241/md.ini
@@ -47,3 +47,10 @@ isohid = coy
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-042
+remedy = Merge
+code = coy
+name = Coyaima
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/cume1234/md.ini
+++ b/languoids/tree/book1242/cume1234/md.ini
@@ -29,3 +29,10 @@ isohid = cum
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-030
+remedy = Retire
+code = cum
+name = Cumeral
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/gbat1238/md.ini
+++ b/languoids/tree/book1242/gbat1238/md.ini
@@ -32,3 +32,10 @@ isohid = gti
 comment_type = Spurious
 ethnologue_versions = E16/E17
 
+[iso_retirement]
+change_request = 2014-051
+remedy = Merge
+code = gti
+name = Gbati-ri
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/geya1234/md.ini
+++ b/languoids/tree/book1242/geya1234/md.ini
@@ -28,3 +28,10 @@ isohid = guv
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-001
+remedy = Merge
+code = guv
+name = Gey
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/gugu1257/md.ini
+++ b/languoids/tree/book1242/gugu1257/md.ini
@@ -40,10 +40,12 @@ comment = Gugu Mini” is apparently a generic term meaning “good speech” th
 	Kokomini (Y94) to refer to one specific tribe.
 code = ggm
 name = Gugu Mini
-effective = 2014-02-03
+effective = 2013-01-23 
 remedy = This name is a cover term for several related languages and is not an individual language.
 reason = non-existent
-change_request = 2013-030
+change_request = 2012-138
+supersedes = 
+	ggr
 
 [hh_ethnologue_comment]
 comment = E17 has an entry Gugu Mini [ggm] with little information beyond this name and

--- a/languoids/tree/book1242/iapa1241/md.ini
+++ b/languoids/tree/book1242/iapa1241/md.ini
@@ -43,3 +43,10 @@ isohid = iap
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18/E19
 
+[iso_retirement]
+change_request = 2015-037
+remedy = Retire
+code = iap
+name = Iapama
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/imer1236/md.ini
+++ b/languoids/tree/book1242/imer1236/md.ini
@@ -65,3 +65,10 @@ isohid = ime
 comment_type = Spurious
 ethnologue_versions = E16/E17
 
+[iso_retirement]
+change_request = 2014-027
+remedy = Retire
+code = ime
+name = Imeraguen
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/kabi1264/md.ini
+++ b/languoids/tree/book1242/kabi1264/md.ini
@@ -61,3 +61,10 @@ isohid = xbx
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-026
+remedy = Retire
+code = xbx
+name = Kabixí
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/kaka1269/md.ini
+++ b/languoids/tree/book1242/kaka1269/md.ini
@@ -29,3 +29,10 @@ isohid = kbf
 comment_type = Spurious
 ethnologue_versions = E16/E17
 
+[iso_retirement]
+change_request = 2014-047
+remedy = Retire
+code = kbf
+name = Kakauhua
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/kaki1247/md.ini
+++ b/languoids/tree/book1242/kaki1247/md.ini
@@ -42,3 +42,10 @@ isohid = kxe
 comment_type = Spurious
 ethnologue_versions = E16/E17
 
+[iso_retirement]
+change_request = 2014-040
+remedy = Merge
+code = kxe
+name = Kakihum
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/kamb1287/md.ini
+++ b/languoids/tree/book1242/kamb1287/md.ini
@@ -32,3 +32,10 @@ isohid = xba
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-025
+remedy = Retire
+code = xba
+name = Kamba (Brazil)
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/kung1262/md.ini
+++ b/languoids/tree/book1242/kung1262/md.ini
@@ -24,3 +24,10 @@ ethnologue_versions = E16/E17/E18
 [identifier]
 endangeredlanguages = 4456
 
+[iso_retirement]
+change_request = 2015-004
+remedy = Retire
+code = kvs
+name = Kunggara
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/kwak1264/md.ini
+++ b/languoids/tree/book1242/kwak1264/md.ini
@@ -35,3 +35,10 @@ isohid = kwq
 comment_type = Spurious
 ethnologue_versions = E16/E17
 
+[iso_retirement]
+change_request = 2014-044
+remedy = Merge
+code = kwq
+name = Kwak
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/kxau1241/md.ini
+++ b/languoids/tree/book1242/kxau1241/md.ini
@@ -52,3 +52,10 @@ lgcode =
 multitree = aue
 endangeredlanguages = 9389
 
+[iso_retirement]
+change_request = 2014-059
+remedy = Retire
+code = aue
+name = =/Kx'au//'ein
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/ling1268/md.ini
+++ b/languoids/tree/book1242/ling1268/md.ini
@@ -24,3 +24,10 @@ isohid = lii
 comment_type = Spurious
 ethnologue_versions = E16/E17
 
+[iso_retirement]
+change_request = 2014-048
+remedy = Merge
+code = lii
+name = Lingkhim
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/luaa1235/md.ini
+++ b/languoids/tree/book1242/luaa1235/md.ini
@@ -44,3 +44,10 @@ lgcode =
 multitree = prb
 endangeredlanguages = 5288
 
+[iso_retirement]
+change_request = 2016-010
+remedy = Retire
+code = prb
+name = Lua'
+effective = 2017-01-31 
+

--- a/languoids/tree/book1242/mali1287/md.ini
+++ b/languoids/tree/book1242/mali1287/md.ini
@@ -26,3 +26,10 @@ isohid = mwj
 comment_type = Spurious
 ethnologue_versions = E16/E17
 
+[iso_retirement]
+change_request = 2014-057
+remedy = Merge
+code = mwj
+name = Maligo
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/mund1321/md.ini
+++ b/languoids/tree/book1242/mund1321/md.ini
@@ -36,3 +36,9 @@ isohid = unx
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18/E19
 
+[iso_retirement]
+change_request = 2007-065
+effective = 2008-02-18 
+supersedes = 
+	muw
+

--- a/languoids/tree/book1242/nata1238/md.ini
+++ b/languoids/tree/book1242/nata1238/md.ini
@@ -34,3 +34,10 @@ isohid = nts
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-042
+remedy = Merge
+code = nts
+name = Natagaimas
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/ngon1275/md.ini
+++ b/languoids/tree/book1242/ngon1275/md.ini
@@ -27,3 +27,10 @@ ethnologue_versions = E16/E17
 [identifier]
 endangeredlanguages = 555
 
+[iso_retirement]
+change_request = 2014-046
+remedy = Merge
+code = nnx
+name = Ngong
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/nija1242/md.ini
+++ b/languoids/tree/book1242/nija1242/md.ini
@@ -22,3 +22,10 @@ ethnologue_versions = E16/E17/E18
 [identifier]
 endangeredlanguages = 4748
 
+[iso_retirement]
+change_request = 2015-028
+remedy = Retire
+code = nad
+name = Nijadali
+effective =  
+

--- a/languoids/tree/book1242/omej1234/md.ini
+++ b/languoids/tree/book1242/omej1234/md.ini
@@ -29,3 +29,10 @@ isohid = ome
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-031
+remedy = Retire
+code = ome
+name = Omejes
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/oung1238/md.ini
+++ b/languoids/tree/book1242/oung1238/md.ini
@@ -69,3 +69,10 @@ isohid = oun
 comment_type = Spurious
 ethnologue_versions = E16/E17
 
+[iso_retirement]
+change_request = 2014-057
+remedy = Merge
+code = oun
+name = !O!ung
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/paoo1245/md.ini
+++ b/languoids/tree/book1242/paoo1245/md.ini
@@ -44,3 +44,10 @@ isohid = ppa
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-012
+remedy = Merge
+code = ppa
+name = Pao
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/piru1241/md.ini
+++ b/languoids/tree/book1242/piru1241/md.ini
@@ -83,9 +83,11 @@ comment = In the previous cycle, the languages Piru and Luhu were combined, as t
 	West Piru Bay languages – except Batumerah, as noted above.” (Collins 2003)
 code = ppr
 name = Piru
-effective = 2013-01-23
+effective = 2012-02-03 
 remedy = [lcq]
-change_request = 2012-096
+change_request = 2011-084
+supersedes = 
+	lcq
 
 [identifier]
 multitree = ppr

--- a/languoids/tree/book1242/pona1251/md.ini
+++ b/languoids/tree/book1242/pona1251/md.ini
@@ -29,3 +29,10 @@ isohid = pod
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-032
+remedy = Retire
+code = pod
+name = Ponares
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/pray1239/md.ini
+++ b/languoids/tree/book1242/pray1239/md.ini
@@ -51,3 +51,10 @@ isohid = pry
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-045
+remedy = Retire
+code = pry
+name = Pray 3
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/puko1234/md.ini
+++ b/languoids/tree/book1242/puko1234/md.ini
@@ -23,3 +23,10 @@ isohid = puk
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18/E19
 
+[iso_retirement]
+change_request = 2016-011
+remedy = Retire
+code = puk
+name = Pu Ko
+effective = 2017-01-31 
+

--- a/languoids/tree/book1242/rien1238/md.ini
+++ b/languoids/tree/book1242/rien1238/md.ini
@@ -29,3 +29,10 @@ lexvo =
 [identifier]
 multitree = rie
 
+[iso_retirement]
+change_request = 2016-005
+remedy = Retire
+code = rie
+name = Rien
+effective = 2017-01-31 
+

--- a/languoids/tree/book1242/sara1320/md.ini
+++ b/languoids/tree/book1242/sara1320/md.ini
@@ -39,3 +39,10 @@ isohid = koj
 comment_type = Spurious
 ethnologue_versions = E16/E17
 
+[iso_retirement]
+change_request = 2014-030
+remedy = Merge
+code = koj
+name = Sara Dunjo
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/sava1244/md.ini
+++ b/languoids/tree/book1242/sava1244/md.ini
@@ -29,3 +29,10 @@ isohid = svr
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-010
+remedy = Retire
+code = svr
+name = Savara
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/song1304/md.ini
+++ b/languoids/tree/book1242/song1304/md.ini
@@ -37,3 +37,10 @@ isohid = sgo
 comment_type = Spurious
 ethnologue_versions = E16/E17
 
+[iso_retirement]
+change_request = 2014-028
+remedy = Retire
+code = sgo
+name = Songa
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/sout2718/md.ini
+++ b/languoids/tree/book1242/sout2718/md.ini
@@ -15,3 +15,10 @@ status = Vulnerable
 [sources]
 glottolog = 
 
+[iso_retirement]
+change_request = 2014-035
+remedy = Merge
+code = tsf
+name = Southwestern Tamang
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/sout3128/md.ini
+++ b/languoids/tree/book1242/sout3128/md.ini
@@ -28,3 +28,9 @@ isohid = nsv
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18/E19
 
+[iso_retirement]
+change_request = 2007-086
+effective = 2008-01-14 
+supersedes = 
+	yym
+

--- a/languoids/tree/book1242/subi1247/md.ini
+++ b/languoids/tree/book1242/subi1247/md.ini
@@ -14,3 +14,10 @@ countries =
 [sources]
 glottolog = 
 
+[iso_retirement]
+change_request = 2014-050
+remedy = Retire
+code = xsj
+name = Subi
+effective =  
+

--- a/languoids/tree/book1242/taih1245/md.ini
+++ b/languoids/tree/book1242/taih1245/md.ini
@@ -37,3 +37,10 @@ lgcode =
 [identifier]
 multitree = thc
 
+[iso_retirement]
+change_request = 2015-018
+remedy = Merge
+code = thc
+name = Tai Hang Tong
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/tawa1289/md.ini
+++ b/languoids/tree/book1242/tawa1289/md.ini
@@ -30,3 +30,9 @@ ethnologue_versions = E16/E17/E18/E19
 [identifier]
 endangeredlanguages = 5626
 
+[iso_retirement]
+change_request = 2006-034
+effective = 2007-07-18 
+supersedes = 
+	mob
+

--- a/languoids/tree/book1242/thee1240/md.ini
+++ b/languoids/tree/book1242/thee1240/md.ini
@@ -37,3 +37,10 @@ isohid = thx
 comment_type = Spurious
 ethnologue_versions = E16/E17
 
+[iso_retirement]
+change_request = 2014-014
+remedy = Retire
+code = thx
+name = The
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/tome1239/md.ini
+++ b/languoids/tree/book1242/tome1239/md.ini
@@ -29,3 +29,10 @@ isohid = toe
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-033
+remedy = Retire
+code = toe
+name = Tomedes
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/uokh1238/md.ini
+++ b/languoids/tree/book1242/uokh1238/md.ini
@@ -34,3 +34,10 @@ isohid = uok
 comment_type = Spurious
 ethnologue_versions = E16/E17
 
+[iso_retirement]
+change_request = 2014-043
+remedy = Merge
+code = uok
+name = Uokha
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/yang1292/md.ini
+++ b/languoids/tree/book1242/yang1292/md.ini
@@ -41,3 +41,10 @@ isohid = ynh
 comment_type = Spurious
 ethnologue_versions = E16/E17
 
+[iso_retirement]
+change_request = 2014-052
+remedy = Retire
+code = ynh
+name = Yangho
+effective = 2015-01-12 
+

--- a/languoids/tree/book1242/yari1235/md.ini
+++ b/languoids/tree/book1242/yari1235/md.ini
@@ -43,3 +43,10 @@ isohid = yri
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-022
+remedy = Retire
+code = yri
+name = Yarí
+effective = 2016-01-15 
+

--- a/languoids/tree/book1242/yidd1241/md.ini
+++ b/languoids/tree/book1242/yidd1241/md.ini
@@ -23,3 +23,10 @@ lexvo =
 [identifier]
 multitree = yds
 
+[iso_retirement]
+change_request = 2014-010
+remedy = Retire
+code = yds
+name = Yiddish Sign Language
+effective = 2015-01-12 
+

--- a/languoids/tree/cent2225/sara1341/sbbo1237/nucl1719/sara1349/sara1318/barh1234/sara1348/sara1321/md.ini
+++ b/languoids/tree/cent2225/sara1341/sbbo1237/nucl1719/sara1349/sara1318/barh1234/sara1348/sara1321/md.ini
@@ -42,3 +42,9 @@ sub = **hh:hv:Djarangar:Sara**
 subrefs = 
 	**hh:hv:Djarangar:Sara**
 
+[iso_retirement]
+change_request = 2014-030
+effective = 2015-01-12 
+supersedes = 
+	koj
+

--- a/languoids/tree/dogo1299/nang1263/bank1259/md.ini
+++ b/languoids/tree/dogo1299/nang1263/bank1259/md.ini
@@ -37,3 +37,9 @@ subrefs =
 [identifier]
 endangeredlanguages = 8732
 
+[iso_retirement]
+change_request = 2011-070
+effective = 2012-02-03 
+supersedes = 
+	dwl
+

--- a/languoids/tree/dogo1299/nang1263/bent1238/md.ini
+++ b/languoids/tree/dogo1299/nang1263/bent1238/md.ini
@@ -31,3 +31,9 @@ subrefs =
 [identifier]
 endangeredlanguages = 8731
 
+[iso_retirement]
+change_request = 2011-070
+effective = 2012-02-03 
+supersedes = 
+	dwl
+

--- a/languoids/tree/dogo1299/west2779/ampa1238/md.ini
+++ b/languoids/tree/dogo1299/west2779/ampa1238/md.ini
@@ -36,3 +36,9 @@ subrefs =
 [identifier]
 endangeredlanguages = 8740
 
+[iso_retirement]
+change_request = 2010-018
+effective = 2011-05-18 
+supersedes = 
+	dkl
+

--- a/languoids/tree/dogo1299/west2779/momb1254/md.ini
+++ b/languoids/tree/dogo1299/west2779/momb1254/md.ini
@@ -41,3 +41,9 @@ subrefs =
 [identifier]
 endangeredlanguages = 8739
 
+[iso_retirement]
+change_request = 2010-018
+effective = 2011-05-18 
+supersedes = 
+	dkl
+

--- a/languoids/tree/drav1251/sout3133/sout3139/gond1265/nort3258/sout2711/md.ini
+++ b/languoids/tree/drav1251/sout3133/sout3139/gond1265/nort3258/sout2711/md.ini
@@ -47,3 +47,10 @@ subrefs =
 	**hh:hv:Garapati:Gondi**
 	**hh:hvwsoc:Beine:Gondi**
 
+[iso_retirement]
+change_request = 2015-062
+remedy = Split
+code = ggo
+name = Southern Gondi
+effective = 2016-01-15 
+

--- a/languoids/tree/garr1260/gara1269/md.ini
+++ b/languoids/tree/garr1260/gara1269/md.ini
@@ -28,3 +28,9 @@ lgcode =
 [identifier]
 endangeredlanguages = 4190
 
+[iso_retirement]
+change_request = 2011-121
+effective = 2012-02-03 
+supersedes = 
+	gbc
+

--- a/languoids/tree/garr1260/wany1247/md.ini
+++ b/languoids/tree/garr1260/wany1247/md.ini
@@ -20,3 +20,9 @@ glottolog =
 [identifier]
 endangeredlanguages = 5259
 
+[iso_retirement]
+change_request = 2011-121
+effective = 2012-02-03 
+supersedes = 
+	gbc
+

--- a/languoids/tree/gong1255/omet1238/nort3161/cent2046/dawr1235/dawr1236/md.ini
+++ b/languoids/tree/gong1255/omet1238/nort3161/cent2046/dawr1235/dawr1236/md.ini
@@ -43,3 +43,9 @@ sub = **hh:hv:Amha:Ometo**
 subrefs = 
 	**hh:hv:Amha:Ometo**
 
+[iso_retirement]
+change_request = 2008-080
+effective = 2009-01-16 
+supersedes = 
+	gmo
+

--- a/languoids/tree/gong1255/omet1238/nort3161/cent2046/dawr1235/gamo1243/md.ini
+++ b/languoids/tree/gong1255/omet1238/nort3161/cent2046/dawr1235/gamo1243/md.ini
@@ -38,3 +38,9 @@ sub = **hh:hv:Amha:Ometo**
 subrefs = 
 	**hh:hv:Amha:Ometo**
 
+[iso_retirement]
+change_request = 2008-080
+effective = 2009-01-16 
+supersedes = 
+	gmo
+

--- a/languoids/tree/gong1255/omet1238/nort3161/cent2046/dawr1235/gofa1235/md.ini
+++ b/languoids/tree/gong1255/omet1238/nort3161/cent2046/dawr1235/gofa1235/md.ini
@@ -28,3 +28,9 @@ sub = **hh:hv:Amha:Ometo**
 subrefs = 
 	**hh:hv:Amha:Ometo**
 
+[iso_retirement]
+change_request = 2008-080
+effective = 2009-01-16 
+supersedes = 
+	gmo
+

--- a/languoids/tree/hmon1336/hmon1337/nucl1714/nucl1720/west2803/grea1295/chua1248/firs1234/horn1235/md.ini
+++ b/languoids/tree/hmon1336/hmon1337/nucl1714/nucl1720/west2803/grea1295/chua1248/firs1234/horn1235/md.ini
@@ -65,3 +65,9 @@ sub = **hh:styp:McLaughlin:Hmong-Soud**:6-10
 subrefs = 
 	**hh:styp:McLaughlin:Hmong-Soud**
 
+[iso_retirement]
+change_request = 2007-188
+effective = 2008-01-14 
+supersedes = 
+	blu
+

--- a/languoids/tree/hmon1336/hmon1337/nucl1714/nucl1720/west2803/grea1295/chua1248/firs1234/huam1250/hmon1264/md.ini
+++ b/languoids/tree/hmon1336/hmon1337/nucl1714/nucl1720/west2803/grea1295/chua1248/firs1234/huam1250/hmon1264/md.ini
@@ -69,3 +69,9 @@ sub = **hh:styp:McLaughlin:Hmong-Soud**:6-10
 subrefs = 
 	**hh:styp:McLaughlin:Hmong-Soud**
 
+[iso_retirement]
+change_request = 2007-188
+effective = 2008-01-14 
+supersedes = 
+	blu
+

--- a/languoids/tree/hmon1336/hmon1337/nucl1714/nucl1720/west2803/grea1295/chua1248/smal1236/md.ini
+++ b/languoids/tree/hmon1336/hmon1337/nucl1714/nucl1720/west2803/grea1295/chua1248/smal1236/md.ini
@@ -47,3 +47,9 @@ sub = **hh:styp:McLaughlin:Hmong-Soud**:6-10
 subrefs = 
 	**hh:styp:McLaughlin:Hmong-Soud**
 
+[iso_retirement]
+change_request = 2007-188
+effective = 2008-01-14 
+supersedes = 
+	blu
+

--- a/languoids/tree/indo1319/indo1320/indo1321/indo1322/subc1234/east2726/bagh1251/md.ini
+++ b/languoids/tree/indo1319/indo1320/indo1321/indo1322/subc1234/east2726/bagh1251/md.ini
@@ -44,3 +44,9 @@ subrefs =
 	**hh:hv:Matras:Romani**
 	**hh:hv:Masica:Indo-Aryan**
 
+[iso_retirement]
+change_request = 2015-012
+effective = 2016-01-15 
+supersedes = 
+	ppa
+

--- a/languoids/tree/indo1319/indo1320/indo1321/indo1323/oriy1254/gaud1237/gaud1238/rohi1238/md.ini
+++ b/languoids/tree/indo1319/indo1320/indo1321/indo1323/oriy1254/gaud1237/gaud1238/rohi1238/md.ini
@@ -52,3 +52,9 @@ lgcode =
 [identifier]
 multitree = rhg
 
+[iso_retirement]
+change_request = 2006-048
+effective = 2007-07-18 
+supersedes = 
+	cit
+

--- a/languoids/tree/indo1319/indo1320/indo1321/indo1323/oriy1254/gaud1237/gaud1238/sout3182/chit1275/md.ini
+++ b/languoids/tree/indo1319/indo1320/indo1321/indo1323/oriy1254/gaud1237/gaud1238/sout3182/chit1275/md.ini
@@ -40,3 +40,9 @@ lgcode =
 wals = bec
 multitree = ctg
 
+[iso_retirement]
+change_request = 2006-048
+effective = 2007-07-18 
+supersedes = 
+	cit
+

--- a/languoids/tree/indo1319/indo1320/indo1321/indo1323/oriy1254/gaud1237/kamt1240/rang1265/md.ini
+++ b/languoids/tree/indo1319/indo1320/indo1321/indo1323/oriy1254/gaud1237/kamt1240/rang1265/md.ini
@@ -47,3 +47,9 @@ sub = **hh:hvw:Toulmin:Bangla**
 subrefs = 
 	**hh:hvw:Toulmin:Bangla**
 
+[iso_retirement]
+change_request = 2007-008
+effective = 2008-01-14 
+supersedes = 
+	rjb
+

--- a/languoids/tree/indo1319/indo1320/indo1321/indo1323/oriy1254/gaud1237/kamt1240/west2382/rajb1243/md.ini
+++ b/languoids/tree/indo1319/indo1320/indo1321/indo1323/oriy1254/gaud1237/kamt1240/west2382/rajb1243/md.ini
@@ -39,3 +39,9 @@ sub = **hh:hvw:Toulmin:Bangla**
 subrefs = 
 	**hh:hvw:Toulmin:Bangla**
 
+[iso_retirement]
+change_request = 2007-008
+effective = 2008-01-14 
+supersedes = 
+	rjb
+

--- a/languoids/tree/indo1319/indo1320/indo1321/indo1324/sind1278/lahn1241/paha1251/md.ini
+++ b/languoids/tree/indo1319/indo1320/indo1321/indo1324/sind1278/lahn1241/paha1251/md.ini
@@ -48,3 +48,9 @@ sub = **hh:hv:Shackle:Hindko**
 subrefs = 
 	**hh:hv:Shackle:Hindko**
 
+[iso_retirement]
+change_request = 2014-023
+effective = 2015-01-12 
+supersedes = 
+	pmu
+

--- a/languoids/tree/indo1319/indo1320/indo1321/indo1324/sind1278/lahn1241/panj1259/mirp1238/md.ini
+++ b/languoids/tree/indo1319/indo1320/indo1321/indo1324/sind1278/lahn1241/panj1259/mirp1238/md.ini
@@ -36,3 +36,10 @@ lgcode =
 [identifier]
 multitree = pmu
 
+[iso_retirement]
+change_request = 2014-023
+remedy = Merge
+code = pmu
+name = Mirpur Panjabi
+effective = 2015-01-12 
+

--- a/languoids/tree/indo1319/indo1320/iran1269/sang1343/ishk1246/md.ini
+++ b/languoids/tree/indo1319/indo1320/iran1269/sang1343/ishk1246/md.ini
@@ -21,3 +21,9 @@ subrefs =
 [identifier]
 endangeredlanguages = 5855
 
+[iso_retirement]
+change_request = 2009-029
+effective = 2010-01-18 
+supersedes = 
+	sgl
+

--- a/languoids/tree/indo1319/indo1320/iran1269/sang1343/sang1344/md.ini
+++ b/languoids/tree/indo1319/indo1320/iran1269/sang1343/sang1344/md.ini
@@ -18,3 +18,9 @@ subrefs =
 	**hh:hv:Wendtland:Pamir**
 	**hh:wsoc:Beck:Ishkashimi-Sanglechi**
 
+[iso_retirement]
+change_request = 2009-029
+effective = 2010-01-18 
+supersedes = 
+	sgl
+

--- a/languoids/tree/indo1319/indo1320/iran1269/sout3157/midd1352/mode1259/fars1254/fars1255/east2745/dari1249/md.ini
+++ b/languoids/tree/indo1319/indo1320/iran1269/sout3157/midd1352/mode1259/fars1254/fars1255/east2745/dari1249/md.ini
@@ -78,3 +78,9 @@ sub = **hh:h:Kieffer:Afghanistan**
 subrefs = 
 	**hh:h:Kieffer:Afghanistan**
 
+[iso_retirement]
+change_request = 2009-028
+effective = 2010-01-18 
+supersedes = 
+	drw
+

--- a/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1279/emil1243/emil1241/md.ini
+++ b/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1279/emil1243/emil1241/md.ini
@@ -31,3 +31,9 @@ sub = **hh:hv:Schurr:Romagnolo**
 subrefs = 
 	**hh:hv:Schurr:Romagnolo**
 
+[iso_retirement]
+change_request = 2008-040
+effective = 2009-01-16 
+supersedes = 
+	eml
+

--- a/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1279/emil1243/roma1328/md.ini
+++ b/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1279/emil1243/roma1328/md.ini
@@ -45,3 +45,9 @@ lgcode =
 multitree = rgn
 endangeredlanguages = 3206
 
+[iso_retirement]
+change_request = 2008-040
+effective = 2009-01-16 
+supersedes = 
+	eml
+

--- a/languoids/tree/kxaa1236/juku1256/vase1234/md.ini
+++ b/languoids/tree/kxaa1236/juku1256/vase1234/md.ini
@@ -19,3 +19,11 @@ sub = **hh:hv:Sands:Juu**
 subrefs = 
 	**hh:hv:Sands:Juu**
 
+[iso_retirement]
+change_request = 2014-057
+effective = 2015-01-12 
+supersedes = 
+	gfx
+	mwj
+	oun
+

--- a/languoids/tree/leng1261/leng1263/anga1316/md.ini
+++ b/languoids/tree/leng1261/leng1263/anga1316/md.ini
@@ -19,3 +19,9 @@ subrefs =
 [identifier]
 endangeredlanguages = 1572
 
+[iso_retirement]
+change_request = 2013-013
+effective = 2014-02-03 
+supersedes = 
+	sap
+

--- a/languoids/tree/leng1261/leng1263/sana1298/md.ini
+++ b/languoids/tree/leng1261/leng1263/sana1298/md.ini
@@ -19,3 +19,9 @@ subrefs =
 [identifier]
 endangeredlanguages = 2752
 
+[iso_retirement]
+change_request = 2013-013
+effective = 2014-02-03 
+supersedes = 
+	sap
+

--- a/languoids/tree/mand1469/east2697/sout3140/guro1245/guro1246/dant1235/dann1241/klad1234/md.ini
+++ b/languoids/tree/mand1469/east2697/sout3140/guro1245/guro1246/dant1235/dann1241/klad1234/md.ini
@@ -9,3 +9,9 @@ countries =
 macroareas = 
 	Africa
 
+[iso_retirement]
+change_request = 2012-083
+effective = 2013-01-23 
+supersedes = 
+	daf
+

--- a/languoids/tree/mand1469/east2697/sout3140/guro1245/guro1246/dant1235/dann1241/nucl1770/md.ini
+++ b/languoids/tree/mand1469/east2697/sout3140/guro1245/guro1246/dant1235/dann1241/nucl1770/md.ini
@@ -11,3 +11,9 @@ macroareas =
 longitude = -8.15
 latitude = 7.27
 
+[iso_retirement]
+change_request = 2012-083
+effective = 2013-01-23 
+supersedes = 
+	daf
+

--- a/languoids/tree/maya1287/core1254/quic1274/grea1276/core1251/cakc1244/kaqc1270/md.ini
+++ b/languoids/tree/maya1287/core1254/quic1274/grea1276/core1251/cakc1244/kaqc1270/md.ini
@@ -81,3 +81,17 @@ sub = **hh:hv:Campbell:Mayan:2015**
 subrefs = 
 	**hh:hv:Campbell:Mayan:2015**
 
+[iso_retirement]
+change_request = 2008-053
+effective = 2009-01-16 
+supersedes = 
+	cbm
+	ckc
+	ckd
+	cke
+	ckf
+	cki
+	ckj
+	ckk
+	ckw
+

--- a/languoids/tree/maya1287/core1254/quic1274/grea1276/core1251/cakc1244/tzut1248/md.ini
+++ b/languoids/tree/maya1287/core1254/quic1274/grea1276/core1251/cakc1244/tzut1248/md.ini
@@ -58,3 +58,9 @@ sub = **hh:hv:Campbell:Mayan:2015**
 subrefs = 
 	**hh:hv:Campbell:Mayan:2015**
 
+[iso_retirement]
+change_request = 2008-062
+effective = 2009-01-16 
+supersedes = 
+	tzt
+

--- a/languoids/tree/maya1287/core1254/quic1274/grea1276/core1251/quic1275/achi1256/md.ini
+++ b/languoids/tree/maya1287/core1254/quic1274/grea1276/core1251/quic1275/achi1256/md.ini
@@ -67,3 +67,9 @@ sub = **hh:hv:Campbell:Mayan:2015**
 subrefs = 
 	**hh:hv:Campbell:Mayan:2015**
 
+[iso_retirement]
+change_request = 2008-048
+effective = 2009-01-16 
+supersedes = 
+	acc
+

--- a/languoids/tree/maya1287/core1254/quic1274/grea1276/core1251/quic1275/kich1262/md.ini
+++ b/languoids/tree/maya1287/core1254/quic1274/grea1276/core1251/quic1275/kich1262/md.ini
@@ -90,3 +90,13 @@ sub = **hh:hv:Campbell:Mayan:2015**
 subrefs = 
 	**hh:hv:Campbell:Mayan:2015**
 
+[iso_retirement]
+change_request = 2008-054
+effective = 2009-01-16 
+supersedes = 
+	cun
+	quj
+	qut
+	quu
+	qxi
+

--- a/languoids/tree/maya1287/core1254/quic1274/grea1276/poco1241/poqo1253/md.ini
+++ b/languoids/tree/maya1287/core1254/quic1274/grea1276/poco1241/poqo1253/md.ini
@@ -66,3 +66,10 @@ sub = **hh:hv:Campbell:Mayan:2015**
 subrefs = 
 	**hh:hv:Campbell:Mayan:2015**
 
+[iso_retirement]
+change_request = 2008-057
+effective = 2009-01-16 
+supersedes = 
+	poa
+	pou
+

--- a/languoids/tree/maya1287/core1254/quic1274/grea1276/poco1241/poqo1254/md.ini
+++ b/languoids/tree/maya1287/core1254/quic1274/grea1276/poco1241/poqo1254/md.ini
@@ -68,3 +68,9 @@ sub = **hh:hv:Campbell:Mayan:2015**
 subrefs = 
 	**hh:hv:Campbell:Mayan:2015**
 
+[iso_retirement]
+change_request = 2008-058
+effective = 2009-01-16 
+supersedes = 
+	pob
+

--- a/languoids/tree/maya1287/core1254/quic1274/grea1277/ixil1250/ixil1251/md.ini
+++ b/languoids/tree/maya1287/core1254/quic1274/grea1277/ixil1250/ixil1251/md.ini
@@ -49,3 +49,10 @@ sub = **hh:hv:Campbell:Mayan:2015**
 subrefs = 
 	**hh:hv:Campbell:Mayan:2015**
 
+[iso_retirement]
+change_request = 2008-052
+effective = 2009-01-16 
+supersedes = 
+	ixi
+	ixj
+

--- a/languoids/tree/maya1287/core1254/quic1274/grea1277/mame1240/mamm1241/md.ini
+++ b/languoids/tree/maya1287/core1254/quic1274/grea1277/mame1240/mamm1241/md.ini
@@ -74,3 +74,13 @@ sub = **hh:hv:Campbell:Mayan:2015**
 subrefs = 
 	**hh:hv:Campbell:Mayan:2015**
 
+[iso_retirement]
+change_request = 2008-055
+effective = 2009-01-16 
+supersedes = 
+	mms
+	mpf
+	mtz
+	mvc
+	mvj
+

--- a/languoids/tree/maya1287/core1254/west2865/chol1286/chol1287/chol1281/chol1282/md.ini
+++ b/languoids/tree/maya1287/core1254/west2865/chol1286/chol1287/chol1281/chol1282/md.ini
@@ -85,3 +85,9 @@ sub = **hh:hv:Campbell:Mayan:2015**
 subrefs = 
 	**hh:hv:Campbell:Mayan:2015**
 
+[iso_retirement]
+change_request = 2008-049
+effective = 2009-01-16 
+supersedes = 
+	cti
+

--- a/languoids/tree/maya1287/core1254/west2865/chol1286/tzel1253/tzel1254/md.ini
+++ b/languoids/tree/maya1287/core1254/west2865/chol1286/tzel1253/tzel1254/md.ini
@@ -90,3 +90,9 @@ sub = **hh:hv:Campbell:Mayan:2015**
 subrefs = 
 	**hh:hv:Campbell:Mayan:2015**
 
+[iso_retirement]
+change_request = 2008-060
+effective = 2009-01-16 
+supersedes = 
+	tzb
+

--- a/languoids/tree/maya1287/core1254/west2865/chol1286/tzel1253/tzot1259/md.ini
+++ b/languoids/tree/maya1287/core1254/west2865/chol1286/tzel1253/tzot1259/md.ini
@@ -58,3 +58,13 @@ sub = **hh:hv:Campbell:Mayan:2015**
 subrefs = 
 	**hh:hv:Campbell:Mayan:2015**
 
+[iso_retirement]
+change_request = 2008-061
+effective = 2009-01-16 
+supersedes = 
+	tzc
+	tze
+	tzs
+	tzu
+	tzz
+

--- a/languoids/tree/maya1287/core1254/west2865/kanj1261/chuj1249/chuj1250/md.ini
+++ b/languoids/tree/maya1287/core1254/west2865/kanj1261/chuj1249/chuj1250/md.ini
@@ -51,3 +51,9 @@ sub = **hh:hv:Campbell:Mayan:2015**
 subrefs = 
 	**hh:hv:Campbell:Mayan:2015**
 
+[iso_retirement]
+change_request = 2008-050
+effective = 2009-01-16 
+supersedes = 
+	cnm
+

--- a/languoids/tree/maya1287/core1254/west2865/kanj1261/kanj1262/kanj1263/popt1235/md.ini
+++ b/languoids/tree/maya1287/core1254/west2865/kanj1261/kanj1262/kanj1263/popt1235/md.ini
@@ -63,3 +63,9 @@ sub = **hh:hv:Campbell:Mayan:2015**
 subrefs = 
 	**hh:hv:Campbell:Mayan:2015**
 
+[iso_retirement]
+change_request = 2008-056
+effective = 2009-01-16 
+supersedes = 
+	jai
+

--- a/languoids/tree/maya1287/core1254/yuca1252/yuca1253/yuca1254/md.ini
+++ b/languoids/tree/maya1287/core1254/yuca1252/yuca1253/yuca1254/md.ini
@@ -170,3 +170,9 @@ sub = **hh:hv:Campbell:Mayan:2015**
 subrefs = 
 	**hh:hv:Campbell:Mayan:2015**
 
+[iso_retirement]
+change_request = 2008-063
+effective = 2009-01-16 
+supersedes = 
+	yus
+

--- a/languoids/tree/maya1287/huas1241/huas1242/md.ini
+++ b/languoids/tree/maya1287/huas1241/huas1242/md.ini
@@ -57,3 +57,10 @@ sub = **hh:hvwphon:Norcliffe:Huastecan**
 subrefs = 
 	**hh:hvwphon:Norcliffe:Huastecan**
 
+[iso_retirement]
+change_request = 2008-051
+effective = 2009-01-16 
+supersedes = 
+	hsf
+	hva
+

--- a/languoids/tree/misu1242/suma1272/sumu1234/maya1285/md.ini
+++ b/languoids/tree/misu1242/suma1272/sumu1234/maya1285/md.ini
@@ -35,3 +35,9 @@ sub = **hh:hv:Pineda:Misumalpan**
 subrefs = 
 	**hh:hv:Pineda:Misumalpan**
 
+[iso_retirement]
+change_request = 2009-037
+effective = 2010-01-18 
+supersedes = 
+	sum
+

--- a/languoids/tree/misu1242/suma1272/sumu1234/ulwa1239/md.ini
+++ b/languoids/tree/misu1242/suma1272/sumu1234/ulwa1239/md.ini
@@ -24,3 +24,9 @@ sub = **hh:hv:Pineda:Misumalpan**
 subrefs = 
 	**hh:hv:Pineda:Misumalpan**
 
+[iso_retirement]
+change_request = 2009-037
+effective = 2010-01-18 
+supersedes = 
+	sum
+

--- a/languoids/tree/mixe1287/basq1267/erro1240/md.ini
+++ b/languoids/tree/mixe1287/basq1267/erro1240/md.ini
@@ -17,3 +17,9 @@ glottolog =
 lgcode = 
 	bohemiens
 
+[iso_retirement]
+change_request = 2009-031
+effective = 2010-01-18 
+supersedes = 
+	rmr
+

--- a/languoids/tree/mixe1287/iber1252/calo1236/md.ini
+++ b/languoids/tree/mixe1287/iber1252/calo1236/md.ini
@@ -16,3 +16,9 @@ glottolog =
 lgcode = 
 	calo
 
+[iso_retirement]
+change_request = 2009-031
+effective = 2010-01-18 
+supersedes = 
+	rmr
+

--- a/languoids/tree/mong1329/oira1260/oira1264/khal1273/mong1331/halh1238/md.ini
+++ b/languoids/tree/mong1329/oira1260/oira1264/khal1273/mong1331/halh1238/md.ini
@@ -146,3 +146,9 @@ sub = **hh:hv:Rybatzki:Mongolic**
 subrefs = 
 	**hh:hv:Rybatzki:Mongolic**
 
+[iso_retirement]
+change_request = 2009-020
+effective = 2010-01-18 
+supersedes = 
+	drh
+

--- a/languoids/tree/namb1299/namb1300/nort3153/mama1278/md.ini
+++ b/languoids/tree/namb1299/namb1300/nort3153/mama1278/md.ini
@@ -49,3 +49,9 @@ sub = **hh:g:Eberhard:Mamainde**:21-31
 subrefs = 
 	**hh:g:Eberhard:Mamainde**
 
+[iso_retirement]
+change_request = 2007-017
+effective = 2008-01-14 
+supersedes = 
+	mbg
+

--- a/languoids/tree/namb1299/namb1300/nort3153/roos1235/lako1248/md.ini
+++ b/languoids/tree/namb1299/namb1300/nort3153/roos1235/lako1248/md.ini
@@ -49,3 +49,9 @@ sub = **hh:g:Eberhard:Mamainde**:21-31
 subrefs = 
 	**hh:g:Eberhard:Mamainde**
 
+[iso_retirement]
+change_request = 2007-017
+effective = 2008-01-14 
+supersedes = 
+	mbg
+

--- a/languoids/tree/namb1299/namb1300/nort3153/roos1235/latu1238/md.ini
+++ b/languoids/tree/namb1299/namb1300/nort3153/roos1235/latu1238/md.ini
@@ -48,3 +48,9 @@ sub = **hh:g:Eberhard:Mamainde**:21-31
 subrefs = 
 	**hh:g:Eberhard:Mamainde**
 
+[iso_retirement]
+change_request = 2007-017
+effective = 2008-01-14 
+supersedes = 
+	mbg
+

--- a/languoids/tree/namb1299/namb1300/nort3153/roos1235/tawa1278/md.ini
+++ b/languoids/tree/namb1299/namb1300/nort3153/roos1235/tawa1278/md.ini
@@ -41,3 +41,9 @@ sub = **hh:g:Eberhard:Mamainde**:21-31
 subrefs = 
 	**hh:g:Eberhard:Mamainde**
 
+[iso_retirement]
+change_request = 2007-017
+effective = 2008-01-14 
+supersedes = 
+	mbg
+

--- a/languoids/tree/nduu1242/nucl1642/sawo1235/sawo1234/keak1239/md.ini
+++ b/languoids/tree/nduu1242/nucl1642/sawo1235/sawo1234/keak1239/md.ini
@@ -42,3 +42,9 @@ subrefs =
 	**hh:soc:Richardson:Kundi-Ambakich**
 	**hh:g:Jendraschek:Iatmul**
 
+[iso_retirement]
+change_request = 2008-022
+effective = 2009-01-16 
+supersedes = 
+	sic
+

--- a/languoids/tree/nduu1242/nucl1642/sawo1235/sawo1234/sosk1235/md.ini
+++ b/languoids/tree/nduu1242/nucl1642/sawo1235/sawo1234/sosk1235/md.ini
@@ -41,3 +41,9 @@ subrefs =
 	**hh:soc:Richardson:Kundi-Ambakich**
 	**hh:g:Jendraschek:Iatmul**
 
+[iso_retirement]
+change_request = 2008-022
+effective = 2009-01-16 
+supersedes = 
+	sic
+

--- a/languoids/tree/nucl1708/nucl1722/yang1294/ambr1239/md.ini
+++ b/languoids/tree/nucl1708/nucl1722/yang1294/ambr1239/md.ini
@@ -23,3 +23,9 @@ sub = **hh:hvw:Laycock:Lumi**:48 and p.c. Matthew Dryer
 subrefs = 
 	**hh:hvw:Laycock:Lumi**
 
+[iso_retirement]
+change_request = 2006-057
+effective = 2007-07-18 
+supersedes = 
+	mzf
+

--- a/languoids/tree/nucl1708/nucl1722/yang1294/yang1303/yang1295/md.ini
+++ b/languoids/tree/nucl1708/nucl1722/yang1294/yang1303/yang1295/md.ini
@@ -28,3 +28,9 @@ sub = **hh:hv:Laycock:Sepik**
 subrefs = 
 	**hh:hv:Laycock:Sepik**
 
+[iso_retirement]
+change_request = 2006-057
+effective = 2007-07-18 
+supersedes = 
+	mzf
+

--- a/languoids/tree/nucl1708/nucl1722/yang1294/yang1303/yang1296/md.ini
+++ b/languoids/tree/nucl1708/nucl1722/yang1294/yang1303/yang1296/md.ini
@@ -34,3 +34,9 @@ sub = **hh:hv:Laycock:Sepik**
 subrefs = 
 	**hh:hv:Laycock:Sepik**
 
+[iso_retirement]
+change_request = 2006-057
+effective = 2007-07-18 
+supersedes = 
+	mzf
+

--- a/languoids/tree/nucl1708/nucl1722/yang1294/yang1303/yang1297/md.ini
+++ b/languoids/tree/nucl1708/nucl1722/yang1294/yang1303/yang1297/md.ini
@@ -28,3 +28,9 @@ sub = **hh:hv:Laycock:Sepik**
 subrefs = 
 	**hh:hv:Laycock:Sepik**
 
+[iso_retirement]
+change_request = 2006-057
+effective = 2007-07-18 
+supersedes = 
+	mzf
+

--- a/languoids/tree/nucl1709/bina1276/bina1279/nucl1603/sout2934/orok1268/aeka1244/md.ini
+++ b/languoids/tree/nucl1709/bina1276/bina1279/nucl1603/sout2934/orok1268/aeka1244/md.ini
@@ -29,3 +29,9 @@ sub = **hh:hv:Smallhorn:Binanderean**
 subrefs = 
 	**hh:hv:Smallhorn:Binanderean**
 
+[iso_retirement]
+change_request = 2007-190
+effective = 2008-01-14 
+supersedes = 
+	ork
+

--- a/languoids/tree/nucl1709/bina1276/bina1279/nucl1603/sout2934/orok1268/hunj1241/md.ini
+++ b/languoids/tree/nucl1709/bina1276/bina1279/nucl1603/sout2934/orok1268/hunj1241/md.ini
@@ -35,3 +35,9 @@ sub = **hh:hv:Smallhorn:Binanderean**
 subrefs = 
 	**hh:hv:Smallhorn:Binanderean**
 
+[iso_retirement]
+change_request = 2007-190
+effective = 2008-01-14 
+supersedes = 
+	ork
+

--- a/languoids/tree/nucl1709/bina1276/bina1279/nucl1603/sout2934/orok1268/orok1269/md.ini
+++ b/languoids/tree/nucl1709/bina1276/bina1279/nucl1603/sout2934/orok1268/orok1269/md.ini
@@ -46,3 +46,9 @@ sub = **hh:hv:Smallhorn:Binanderean**
 subrefs = 
 	**hh:hv:Smallhorn:Binanderean**
 
+[iso_retirement]
+change_request = 2007-190
+effective = 2008-01-14 
+supersedes = 
+	ork
+

--- a/languoids/tree/nucl1709/cent2116/awyu1265/grea1275/beck1235/koro1312/md.ini
+++ b/languoids/tree/nucl1709/cent2116/awyu1265/grea1275/beck1235/koro1312/md.ini
@@ -39,3 +39,9 @@ sub = **hh:hv:deVriesetal:Greater-Awyu**
 subrefs = 
 	**hh:hv:deVriesetal:Greater-Awyu**
 
+[iso_retirement]
+change_request = 2007-222
+effective = 2008-01-14 
+supersedes = 
+	krg
+

--- a/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/nort2987/yate1242/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/nort2987/yate1242/md.ini
@@ -38,3 +38,9 @@ sub = **hh:hv:Operstein:Zapotec**
 subrefs = 
 	**hh:hv:Operstein:Zapotec**
 
+[iso_retirement]
+change_request = 2006-027
+effective = 2007-07-18 
+supersedes = 
+	ztc
+

--- a/languoids/tree/pama1250/aran1266/thur1253/core1260/unun9967/nauo1235/md.ini
+++ b/languoids/tree/pama1250/aran1266/thur1253/core1260/unun9967/nauo1235/md.ini
@@ -29,3 +29,9 @@ subrefs =
 	**hh:hv:SimpsonHercus:Thura-Yura**
 	**hh:hv:BowernAtkinson:Pama-Nyungan**
 
+[iso_retirement]
+change_request = 2011-133
+effective = 2012-02-03 
+supersedes = 
+	wiw
+

--- a/languoids/tree/pama1250/aran1266/thur1253/wira1265/md.ini
+++ b/languoids/tree/pama1250/aran1266/thur1253/wira1265/md.ini
@@ -29,3 +29,9 @@ subrefs =
 [identifier]
 endangeredlanguages = 3344
 
+[iso_retirement]
+change_request = 2011-133
+effective = 2012-02-03 
+supersedes = 
+	wiw
+

--- a/languoids/tree/pama1250/karn1253/ngur1261/badj1244/md.ini
+++ b/languoids/tree/pama1250/karn1253/ngur1261/badj1244/md.ini
@@ -32,3 +32,9 @@ isohid = jbi
 comment_type = Spurious
 ethnologue_versions = E17/E18/E19
 
+[iso_retirement]
+change_request = 2012-077
+effective = 2013-01-23 
+supersedes = 
+	nbx
+

--- a/languoids/tree/pama1250/karn1253/ngur1261/kala1380/md.ini
+++ b/languoids/tree/pama1250/karn1253/ngur1261/kala1380/md.ini
@@ -30,3 +30,9 @@ isohid = gll
 comment_type = Spurious
 ethnologue_versions = E17/E18/E19
 
+[iso_retirement]
+change_request = 2012-077
+effective = 2013-01-23 
+supersedes = 
+	nbx
+

--- a/languoids/tree/pama1250/karn1253/ngur1261/punt1240/md.ini
+++ b/languoids/tree/pama1250/karn1253/ngur1261/punt1240/md.ini
@@ -24,3 +24,9 @@ ethnologue_versions = E17/E18/E19
 [identifier]
 endangeredlanguages = 6722
 
+[iso_retirement]
+change_request = 2012-077
+effective = 2013-01-23 
+supersedes = 
+	nbx
+

--- a/languoids/tree/pama1250/karn1253/ngur1261/wong1246/md.ini
+++ b/languoids/tree/pama1250/karn1253/ngur1261/wong1246/md.ini
@@ -24,3 +24,9 @@ ethnologue_versions = E17/E18/E19
 [identifier]
 endangeredlanguages = 6803
 
+[iso_retirement]
+change_request = 2012-077
+effective = 2013-01-23 
+supersedes = 
+	nbx
+

--- a/languoids/tree/pama1250/pama1251/maya1279/nucl1332/mayk1239/mayi1234/md.ini
+++ b/languoids/tree/pama1250/pama1251/maya1279/nucl1332/mayk1239/mayi1234/md.ini
@@ -23,3 +23,9 @@ ethnologue_versions = E17/E18/E19
 [identifier]
 endangeredlanguages = 6699
 
+[iso_retirement]
+change_request = 2012-007
+effective = 2013-01-23 
+supersedes = 
+	mnt
+

--- a/languoids/tree/pama1250/pama1251/maya1279/nucl1332/mayk1239/mayi1235/md.ini
+++ b/languoids/tree/pama1250/pama1251/maya1279/nucl1332/mayk1239/mayi1235/md.ini
@@ -20,3 +20,9 @@ isohid = xyj
 comment_type = Spurious
 ethnologue_versions = E17/E18/E19
 
+[iso_retirement]
+change_request = 2012-007
+effective = 2013-01-23 
+supersedes = 
+	mnt
+

--- a/languoids/tree/pama1250/pama1251/maya1279/nucl1332/mayk1239/mayi1236/md.ini
+++ b/languoids/tree/pama1250/pama1251/maya1279/nucl1332/mayk1239/mayi1236/md.ini
@@ -23,3 +23,9 @@ ethnologue_versions = E17/E18/E19
 [identifier]
 endangeredlanguages = 6698
 
+[iso_retirement]
+change_request = 2012-007
+effective = 2013-01-23 
+supersedes = 
+	mnt
+

--- a/languoids/tree/pama1250/pama1251/rarm1238/ikar1243/md.ini
+++ b/languoids/tree/pama1250/pama1251/rarm1238/ikar1243/md.ini
@@ -32,3 +32,9 @@ isohid = ikr
 comment_type = Missing
 ethnologue_versions = E16
 
+[iso_retirement]
+change_request = 2012-138
+effective = 2013-01-23 
+supersedes = 
+	ggr
+

--- a/languoids/tree/pama1250/pama1251/sout3141/coas1313/yiry1245/dang1262/md.ini
+++ b/languoids/tree/pama1250/pama1251/sout3141/coas1313/yiry1245/dang1262/md.ini
@@ -29,3 +29,9 @@ isohid = yrm
 comment_type = Spurious
 ethnologue_versions = E19
 
+[iso_retirement]
+change_request = 2012-117
+effective = 2013-01-23 
+supersedes = 
+	yiy
+

--- a/languoids/tree/pama1250/pama1251/sout3141/coas1313/yiry1245/jirj1239/md.ini
+++ b/languoids/tree/pama1250/pama1251/sout3141/coas1313/yiry1245/jirj1239/md.ini
@@ -43,3 +43,9 @@ isohid = yyr
 comment_type = Spurious
 ethnologue_versions = E19
 
+[iso_retirement]
+change_request = 2012-117
+effective = 2013-01-23 
+supersedes = 
+	yiy
+

--- a/languoids/tree/pama1250/sout3134/pilb1234/mant1266/djiw1240/djiw1241/md.ini
+++ b/languoids/tree/pama1250/sout3134/pilb1234/mant1266/djiw1240/djiw1241/md.ini
@@ -22,3 +22,9 @@ subrefs =
 [identifier]
 endangeredlanguages = 4088
 
+[iso_retirement]
+change_request = 2012-074
+effective = 2013-01-23 
+supersedes = 
+	djl
+

--- a/languoids/tree/pama1250/sout3134/pilb1234/mant1266/djiw1240/thii1234/md.ini
+++ b/languoids/tree/pama1250/sout3134/pilb1234/mant1266/djiw1240/thii1234/md.ini
@@ -23,3 +23,9 @@ subrefs =
 [identifier]
 endangeredlanguages = 6798
 
+[iso_retirement]
+change_request = 2012-074
+effective = 2013-01-23 
+supersedes = 
+	djl
+

--- a/languoids/tree/pama1250/sout3134/pilb1234/ngay1241/cent2248/pany1247/yinh1234/md.ini
+++ b/languoids/tree/pama1250/sout3134/pilb1234/ngay1241/cent2248/pany1247/yinh1234/md.ini
@@ -18,3 +18,9 @@ subrefs =
 [identifier]
 endangeredlanguages = 6808
 
+[iso_retirement]
+change_request = 2012-075
+effective = 2013-01-23 
+supersedes = 
+	nlr
+

--- a/languoids/tree/pama1250/sout3134/pilb1234/ngay1241/nort3178/ngar1296/md.ini
+++ b/languoids/tree/pama1250/sout3134/pilb1234/ngay1241/nort3178/ngar1296/md.ini
@@ -16,3 +16,9 @@ sub = **hh:hv:BowernAtkinson:Pama-Nyungan**
 subrefs = 
 	**hh:hv:BowernAtkinson:Pama-Nyungan**
 
+[iso_retirement]
+change_request = 2012-075
+effective = 2013-01-23 
+supersedes = 
+	nlr
+

--- a/languoids/tree/pama1250/yarl1237/darl1243/md.ini
+++ b/languoids/tree/pama1250/yarl1237/darl1243/md.ini
@@ -91,3 +91,9 @@ subrefs =
 	**hh:hv:BowernAtkinson:Pama-Nyungan**
 	**hh:hvw:Waferetal:New-South-Wales**
 
+[iso_retirement]
+change_request = 2011-145
+effective = 2012-02-03 
+supersedes = 
+	bjd
+

--- a/languoids/tree/pama1250/yuul1239/sout3142/sout3149/dhuw1248/west2439/dhuw1249/md.ini
+++ b/languoids/tree/pama1250/yuul1239/sout3142/sout3149/dhuw1248/west2439/dhuw1249/md.ini
@@ -70,3 +70,10 @@ subrefs =
 	**hh:g:Wilkinson:Djambarrpuyngu**
 	**hh:hv:BowernAtkinson:Pama-Nyungan**
 
+[iso_retirement]
+change_request = 2015-053
+remedy = Split
+code = duj
+name = Dhuwal
+effective = 2016-01-15 
+

--- a/languoids/tree/quec1387/quec1388/quec1389/boli1262/sout2991/md.ini
+++ b/languoids/tree/quec1387/quec1388/quec1389/boli1262/sout2991/md.ini
@@ -70,3 +70,9 @@ subrefs =
 	**hh:hv:Adelaar:Andes**
 	**hh:hv:Adelaar:Quechua-I-II**
 
+[iso_retirement]
+change_request = 2015-024
+effective = 2016-01-15 
+supersedes = 
+	cqu
+

--- a/languoids/tree/rash1249/tega1236/md.ini
+++ b/languoids/tree/rash1249/tega1236/md.ini
@@ -55,3 +55,9 @@ wals = ori;ras
 multitree = ras;ras-teg
 endangeredlanguages = 182
 
+[iso_retirement]
+change_request = 2010-011
+effective = 2011-05-18 
+supersedes = 
+	tie
+

--- a/languoids/tree/sign1238/deaf1237/lsfi1234/dutc1259/belg1242/lang1248/md.ini
+++ b/languoids/tree/sign1238/deaf1237/lsfi1234/dutc1259/belg1242/lang1248/md.ini
@@ -29,3 +29,9 @@ lexvo =
 [identifier]
 multitree = sfb
 
+[iso_retirement]
+change_request = 2006-001
+effective = 2007-07-18 
+supersedes = 
+	bvs
+

--- a/languoids/tree/sign1238/deaf1237/lsfi1234/dutc1259/belg1242/vlaa1235/md.ini
+++ b/languoids/tree/sign1238/deaf1237/lsfi1234/dutc1259/belg1242/vlaa1235/md.ini
@@ -47,3 +47,9 @@ wals = vla
 multitree = vgt
 endangeredlanguages = 7356
 
+[iso_retirement]
+change_request = 2006-001
+effective = 2007-07-18 
+supersedes = 
+	bvs
+

--- a/languoids/tree/sino1245/bodi1256/bodi1257/oldm1245/tibe1276/amdo1237/md.ini
+++ b/languoids/tree/sino1245/bodi1256/bodi1257/oldm1245/tibe1276/amdo1237/md.ini
@@ -71,3 +71,9 @@ sub = **hh:hv:Tournadre:Tibetic**
 subrefs = 
 	**hh:hv:Tournadre:Tibetic**
 
+[iso_retirement]
+change_request = 2012-029
+effective = 2013-01-23 
+supersedes = 
+	pcr
+

--- a/languoids/tree/sino1245/bodi1256/bodi1257/oldm1245/tibe1276/sout3217/dzon1238/nucl1307/dzon1239/md.ini
+++ b/languoids/tree/sino1245/bodi1256/bodi1257/oldm1245/tibe1276/sout3217/dzon1238/nucl1307/dzon1239/md.ini
@@ -91,3 +91,9 @@ sub = **hh:hv:Tournadre:Tibetic**
 subrefs = 
 	**hh:hv:Tournadre:Tibetic**
 
+[iso_retirement]
+change_request = 2014-049
+effective = 2015-01-12 
+supersedes = 
+	adp
+

--- a/languoids/tree/sino1245/bodi1256/bodi1257/tsha1246/tsha1247/kala1376/md.ini
+++ b/languoids/tree/sino1245/bodi1256/bodi1257/tsha1246/tsha1247/kala1376/md.ini
@@ -34,3 +34,9 @@ sub = **hh:g:Andvik:Tshangla**
 subrefs = 
 	**hh:g:Andvik:Tshangla**
 
+[iso_retirement]
+change_request = 2006-034
+effective = 2007-07-18 
+supersedes = 
+	mob
+

--- a/languoids/tree/sino1245/bodi1256/kaik1248/ghal1247/tama1367/guru1260/guru1261/east2345/md.ini
+++ b/languoids/tree/sino1245/bodi1256/kaik1248/ghal1247/tama1367/guru1260/guru1261/east2345/md.ini
@@ -30,3 +30,10 @@ lexvo =
 multitree = ggn
 endangeredlanguages = 4207
 
+[iso_retirement]
+change_request = 2015-052
+remedy = Merge
+code = ggn
+name = Eastern Gurung
+effective = 2016-01-15 
+

--- a/languoids/tree/sino1245/bodi1256/kaik1248/ghal1247/tama1367/guru1260/guru1261/md.ini
+++ b/languoids/tree/sino1245/bodi1256/kaik1248/ghal1247/tama1367/guru1260/guru1261/md.ini
@@ -31,3 +31,9 @@ subrefs =
 	**hh:s:Noonan:Chantyal**
 	**hh:hv:Honda:Tamangic**
 
+[iso_retirement]
+change_request = 2015-052
+effective = 2016-01-15 
+supersedes = 
+	ggn
+

--- a/languoids/tree/sino1245/bodi1256/kaik1248/ghal1247/tama1367/nucl1729/east2347/md.ini
+++ b/languoids/tree/sino1245/bodi1256/kaik1248/ghal1247/tama1367/nucl1729/east2347/md.ini
@@ -48,3 +48,9 @@ subrefs =
 	**hh:s:Noonan:Chantyal**
 	**hh:hv:Honda:Tamangic**
 
+[iso_retirement]
+change_request = 2014-035
+effective = 2015-01-12 
+supersedes = 
+	tsf
+

--- a/languoids/tree/sino1245/brah1260/jing1259/sakk1239/kado1242/gana1267/md.ini
+++ b/languoids/tree/sino1245/brah1260/jing1259/sakk1239/kado1242/gana1267/md.ini
@@ -26,3 +26,9 @@ isohid = zkn
 comment_type = Spurious
 ethnologue_versions = E17/E18/E19
 
+[iso_retirement]
+change_request = 2011-002
+effective = 2012-02-03 
+supersedes = 
+	kdv
+

--- a/languoids/tree/sino1245/brah1260/jing1259/sakk1239/kado1242/kadu1254/md.ini
+++ b/languoids/tree/sino1245/brah1260/jing1259/sakk1239/kado1242/kadu1254/md.ini
@@ -26,3 +26,9 @@ isohid = zkd
 comment_type = Spurious
 ethnologue_versions = E17/E18/E19
 
+[iso_retirement]
+change_request = 2011-002
+effective = 2012-02-03 
+supersedes = 
+	kdv
+

--- a/languoids/tree/sino1245/brah1260/kony1246/kony1247/khia1235/khia1236/md.ini
+++ b/languoids/tree/sino1245/brah1260/kony1246/kony1247/khia1235/khia1236/md.ini
@@ -42,3 +42,9 @@ sub = **hh:he:Saul:Naga-Burma**
 subrefs = 
 	**hh:he:Saul:Naga-Burma**
 
+[iso_retirement]
+change_request = 2007-252
+effective = 2008-01-14 
+supersedes = 
+	nky
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/burm1266/nort2720/high1273/acha1252/acha1249/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/burm1266/nort2720/high1273/acha1252/acha1249/md.ini
@@ -72,3 +72,9 @@ sub = **hh:soc:Xiong:Achang**
 subrefs = 
 	**hh:soc:Xiong:Achang**
 
+[iso_retirement]
+change_request = 2012-008
+effective = 2013-01-23 
+supersedes = 
+	xia
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/burm1266/sout3159/nucl1730/arak1255/marm1234/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/burm1266/sout3159/nucl1730/arak1255/marm1234/md.ini
@@ -34,3 +34,9 @@ sub = **hh:phon:Bradley:Arakanese**
 subrefs = 
 	**hh:phon:Bradley:Arakanese**
 
+[iso_retirement]
+change_request = 2007-189
+effective = 2008-01-14 
+supersedes = 
+	mhv
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/burm1266/sout3159/nucl1730/arak1255/rakh1245/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/burm1266/sout3159/nucl1730/arak1255/rakh1245/md.ini
@@ -47,3 +47,10 @@ sub = **hh:phon:Bradley:Arakanese**
 subrefs = 
 	**hh:phon:Bradley:Arakanese**
 
+[iso_retirement]
+change_request = 2011-043
+effective = 2012-02-03 
+supersedes = 
+	ccq
+	ybd
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/hani1249/biso1244/biso1241/bisu1246/bisu1244/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/hani1249/biso1244/biso1241/bisu1246/bisu1244/md.ini
@@ -62,3 +62,9 @@ sub = **hh:hvw:Lama:Nisoic**
 subrefs = 
 	**hh:hvw:Lama:Nisoic**
 
+[iso_retirement]
+change_request = 2007-092
+effective = 2008-01-14 
+supersedes = 
+	bii
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/hani1249/biso1244/biso1241/bisu1246/laom1237/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/hani1249/biso1244/biso1241/bisu1246/laom1237/md.ini
@@ -41,3 +41,9 @@ lgcode =
 multitree = lwm
 endangeredlanguages = 4543
 
+[iso_retirement]
+change_request = 2007-092
+effective = 2008-01-14 
+supersedes = 
+	bii
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/laho1234/kuco1235/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/laho1234/kuco1235/md.ini
@@ -40,3 +40,9 @@ lgcode =
 multitree = lkc
 endangeredlanguages = 4510
 
+[iso_retirement]
+change_request = 2007-090
+effective = 2008-01-14 
+supersedes = 
+	kds
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/laho1234/lahu1252/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/laho1234/lahu1252/md.ini
@@ -67,3 +67,9 @@ sub = **hh:hvw:Lama:Nisoic**:157-160
 subrefs = 
 	**hh:hvw:Lama:Nisoic**
 
+[iso_retirement]
+change_request = 2007-090
+effective = 2008-01-14 
+supersedes = 
+	kds
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/liso1234/lipo1243/lipo1244/lipo1242/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/liso1234/lipo1243/lipo1244/lipo1242/md.ini
@@ -44,3 +44,9 @@ subrefs =
 	**hh:hvw:Lama:Nisoic**
 	**hh:hv:Bradley:Tibeto-Burman**
 
+[iso_retirement]
+change_request = 2007-073
+effective = 2008-01-14 
+supersedes = 
+	yio
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/liso1234/lipo1243/unun9959/hler1235/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/liso1234/lipo1243/unun9959/hler1235/md.ini
@@ -33,3 +33,9 @@ lexvo =
 multitree = hle
 endangeredlanguages = 5125
 
+[iso_retirement]
+change_request = 2011-076
+effective = 2012-02-03 
+supersedes = 
+	sca
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/high1272/muji1235/lagh1244/thop1235/core1246/nucl1309/muzi1235/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/high1272/muji1235/lagh1244/thop1235/core1246/nucl1309/muzi1235/md.ini
@@ -45,3 +45,9 @@ sub = **hh:hvsoc:Pelkey:Phula**
 subrefs = 
 	**hh:hvsoc:Pelkey:Phula**
 
+[iso_retirement]
+change_request = 2007-120
+effective = 2008-01-14 
+supersedes = 
+	ymj
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/high1272/muji1235/lagh1244/thop1235/core1246/nucl1309/nort2715/nort2716/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/high1272/muji1235/lagh1244/thop1235/core1246/nucl1309/nort2715/nort2716/md.ini
@@ -43,3 +43,9 @@ sub = **hh:hvsoc:Pelkey:Phula**
 subrefs = 
 	**hh:hvsoc:Pelkey:Phula**
 
+[iso_retirement]
+change_request = 2007-120
+effective = 2008-01-14 
+supersedes = 
+	ymj
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/high1272/muji1235/lagh1244/thop1235/core1246/nucl1309/nort2715/sout2722/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/high1272/muji1235/lagh1244/thop1235/core1246/nucl1309/nort2715/sout2722/md.ini
@@ -44,3 +44,9 @@ sub = **hh:hvsoc:Pelkey:Phula**
 subrefs = 
 	**hh:hvsoc:Pelkey:Phula**
 
+[iso_retirement]
+change_request = 2007-120
+effective = 2008-01-14 
+supersedes = 
+	ymj
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/high1272/muji1235/lagh1244/thop1235/core1246/qila1235/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/high1272/muji1235/lagh1244/thop1235/core1246/qila1235/md.ini
@@ -39,3 +39,9 @@ sub = **hh:hvsoc:Pelkey:Phula**
 subrefs = 
 	**hh:hvsoc:Pelkey:Phula**
 
+[iso_retirement]
+change_request = 2007-120
+effective = 2008-01-14 
+supersedes = 
+	ymj
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/high1272/muji1235/moji1238/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/high1272/muji1235/moji1238/md.ini
@@ -39,3 +39,9 @@ sub = **hh:hvsoc:Pelkey:Phula**
 subrefs = 
 	**hh:hvsoc:Pelkey:Phula**
 
+[iso_retirement]
+change_request = 2007-120
+effective = 2008-01-14 
+supersedes = 
+	ymj
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/high1272/phow1235/anil1235/anip1235/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/high1272/phow1235/anil1235/anip1235/md.ini
@@ -39,3 +39,9 @@ sub = **hh:hvsoc:Pelkey:Phula**
 subrefs = 
 	**hh:hvsoc:Pelkey:Phula**
 
+[iso_retirement]
+change_request = 2007-122
+effective = 2008-01-14 
+supersedes = 
+	ypw
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/high1272/phow1235/anil1235/labo1243/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/high1272/phow1235/anil1235/labo1243/md.ini
@@ -42,3 +42,9 @@ sub = **hh:hvsoc:Pelkey:Phula**
 subrefs = 
 	**hh:hvsoc:Pelkey:Phula**
 
+[iso_retirement]
+change_request = 2007-122
+effective = 2008-01-14 
+supersedes = 
+	ypw
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/high1272/phow1235/hlep1235/hlep1236/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/high1272/phow1235/hlep1235/hlep1236/md.ini
@@ -50,3 +50,9 @@ sub = **hh:hvsoc:Pelkey:Phula**
 subrefs = 
 	**hh:hvsoc:Pelkey:Phula**
 
+[iso_retirement]
+change_request = 2007-122
+effective = 2008-01-14 
+supersedes = 
+	ypw
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/niso1234/nisu1237/nisu1238/sout2723/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/niso1234/nisu1237/nisu1238/sout2723/md.ini
@@ -35,3 +35,9 @@ sub = **hh:hv:Yang:Nisu**
 subrefs = 
 	**hh:hv:Yang:Nisu**
 
+[iso_retirement]
+change_request = 2007-086
+effective = 2008-01-14 
+supersedes = 
+	yym
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/niso1234/nucl1739/nasu1236/nesu1234/nesu1235/wume1235/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/niso1234/nucl1739/nasu1236/nesu1234/nesu1235/wume1235/md.ini
@@ -36,3 +36,9 @@ sub = **hh:hvw:Lama:Nisoic**
 subrefs = 
 	**hh:hvw:Lama:Nisoic**
 
+[iso_retirement]
+change_request = 2007-037
+effective = 2008-01-14 
+supersedes = 
+	ywm
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/rive1256/upri1239/phal1256/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/rive1256/upri1239/phal1256/md.ini
@@ -42,3 +42,9 @@ sub = **hh:hvsoc:Pelkey:Phula**
 subrefs = 
 	**hh:hvsoc:Pelkey:Phula**
 
+[iso_retirement]
+change_request = 2007-121
+effective = 2008-01-14 
+supersedes = 
+	ypl
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/rive1256/upri1239/phol1236/alop1235/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/rive1256/upri1239/phol1236/alop1235/md.ini
@@ -32,3 +32,9 @@ sub = **hh:hvsoc:Pelkey:Phula**
 subrefs = 
 	**hh:hvsoc:Pelkey:Phula**
 
+[iso_retirement]
+change_request = 2007-121
+effective = 2008-01-14 
+supersedes = 
+	ypl
+

--- a/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/rive1256/upri1239/phol1236/phol1237/md.ini
+++ b/languoids/tree/sino1245/burm1265/lolo1265/lolo1267/nili1235/sout3212/rive1256/upri1239/phol1236/phol1237/md.ini
@@ -39,3 +39,9 @@ sub = **hh:hvsoc:Pelkey:Phula**
 subrefs = 
 	**hh:hvsoc:Pelkey:Phula**
 
+[iso_retirement]
+change_request = 2007-121
+effective = 2008-01-14 
+supersedes = 
+	ypl
+

--- a/languoids/tree/sino1245/burm1265/naqi1236/naic1235/nais1236/naxi1245/md.ini
+++ b/languoids/tree/sino1245/burm1265/naqi1236/naic1235/nais1236/naxi1245/md.ini
@@ -56,3 +56,9 @@ sub = **hh:hv:JacquesMichaud:Naxi-Na-Laze**
 subrefs = 
 	**hh:hv:JacquesMichaud:Naxi-Na-Laze**
 
+[iso_retirement]
+change_request = 2010-023
+effective = 2011-05-18 
+supersedes = 
+	nbf
+

--- a/languoids/tree/sino1245/burm1265/naqi1236/naic1235/nais1236/yong1270/md.ini
+++ b/languoids/tree/sino1245/burm1265/naqi1236/naic1235/nais1236/yong1270/md.ini
@@ -31,3 +31,9 @@ sub = **hh:hv:JacquesMichaud:Naxi-Na-Laze**
 subrefs = 
 	**hh:hv:JacquesMichaud:Naxi-Na-Laze**
 
+[iso_retirement]
+change_request = 2010-023
+effective = 2011-05-18 
+supersedes = 
+	nbf
+

--- a/languoids/tree/sino1245/hima1249/maha1306/kira1253/cent2250/kham1300/saam1282/md.ini
+++ b/languoids/tree/sino1245/hima1249/maha1306/kira1253/cent2250/kham1300/saam1282/md.ini
@@ -37,3 +37,9 @@ sub = **hh:hv:vanDriem:Himalayas**
 subrefs = 
 	**hh:hv:vanDriem:Himalayas**
 
+[iso_retirement]
+change_request = 2014-048
+effective = 2015-01-12 
+supersedes = 
+	lii
+

--- a/languoids/tree/sino1245/hima1249/maha1306/kira1253/east2719/uppe1412/loho1238/yamp1244/sout2734/md.ini
+++ b/languoids/tree/sino1245/hima1249/maha1306/kira1253/east2719/uppe1412/loho1238/yamp1244/sout2734/md.ini
@@ -38,3 +38,9 @@ sub = **hh:hwsoc:HiltyMitchell:Yamphu**:52
 subrefs = 
 	**hh:hwsoc:HiltyMitchell:Yamphu**
 
+[iso_retirement]
+change_request = 2011-152
+effective = 2012-02-03 
+supersedes = 
+	yma
+

--- a/languoids/tree/sino1245/hima1249/maha1306/kira1253/east2719/uppe1412/loho1238/yamp1244/yamp1242/md.ini
+++ b/languoids/tree/sino1245/hima1249/maha1306/kira1253/east2719/uppe1412/loho1238/yamp1244/yamp1242/md.ini
@@ -45,3 +45,9 @@ sub = **hh:hwsoc:HiltyMitchell:Yamphu**:52
 subrefs = 
 	**hh:hwsoc:HiltyMitchell:Yamphu**
 
+[iso_retirement]
+change_request = 2006-109
+effective = 2007-07-18 
+supersedes = 
+	tmx
+

--- a/languoids/tree/sino1245/kare1337/sout1554/paku1240/mobw1234/md.ini
+++ b/languoids/tree/sino1245/kare1337/sout1554/paku1240/mobw1234/md.ini
@@ -21,3 +21,9 @@ sub = **hh:hv:Shintani:Brakaloungic**
 subrefs = 
 	**hh:hv:Shintani:Brakaloungic**
 
+[iso_retirement]
+change_request = 2011-059
+effective = 2012-02-03 
+supersedes = 
+	kpp
+

--- a/languoids/tree/sino1245/khob1235/kame1250/meyi1234/chug1251/chug1252/md.ini
+++ b/languoids/tree/sino1245/khob1235/kame1250/meyi1234/chug1251/chug1252/md.ini
@@ -36,3 +36,9 @@ subrefs =
 	**hh:hvw:BlenchPost:Arunachal**
 	**hh:hv:Anderson:West-Kameng**
 
+[iso_retirement]
+change_request = 2006-034
+effective = 2007-07-18 
+supersedes = 
+	mob
+

--- a/languoids/tree/sino1245/khob1235/kame1250/meyi1234/chug1251/lish1235/md.ini
+++ b/languoids/tree/sino1245/khob1235/kame1250/meyi1234/chug1251/lish1235/md.ini
@@ -37,3 +37,9 @@ subrefs =
 	**hh:hvw:BlenchPost:Arunachal**
 	**hh:hv:Anderson:West-Kameng**
 
+[iso_retirement]
+change_request = 2006-034
+effective = 2007-07-18 
+supersedes = 
+	mob
+

--- a/languoids/tree/sino1245/khob1235/kame1250/meyi1234/sher1256/sart1249/md.ini
+++ b/languoids/tree/sino1245/khob1235/kame1250/meyi1234/sher1256/sart1249/md.ini
@@ -41,3 +41,9 @@ subrefs =
 	**hh:hvw:BlenchPost:Arunachal**
 	**hh:hv:Anderson:West-Kameng**
 
+[iso_retirement]
+change_request = 2006-034
+effective = 2007-07-18 
+supersedes = 
+	mob
+

--- a/languoids/tree/sino1245/kuki1245/kuki1246/cent2005/laic1236/fala1242/fala1243/md.ini
+++ b/languoids/tree/sino1245/kuki1245/kuki1246/cent2005/laic1236/fala1242/fala1243/md.ini
@@ -47,3 +47,9 @@ sub = **hh:hv:VanBik:Proto-Kuki-Chin**
 subrefs = 
 	**hh:hv:VanBik:Proto-Kuki-Chin**
 
+[iso_retirement]
+change_request = 2006-023
+effective = 2007-07-18 
+supersedes = 
+	flm
+

--- a/languoids/tree/sino1245/kuki1245/kuki1246/oldk1252/rang1267/md.ini
+++ b/languoids/tree/sino1245/kuki1245/kuki1246/oldk1252/rang1267/md.ini
@@ -30,3 +30,9 @@ subrefs =
 	**hh:hv:VanBik:Proto-Kuki-Chin**
 	**hh:vwphon:MortensenKeogh:Sorbung**
 
+[iso_retirement]
+change_request = 2006-023
+effective = 2007-07-18 
+supersedes = 
+	flm
+

--- a/languoids/tree/sino1245/kuki1245/kuki1246/peri1260/nort3179/siza1239/zouu1235/md.ini
+++ b/languoids/tree/sino1245/kuki1245/kuki1246/peri1260/nort3179/siza1239/zouu1235/md.ini
@@ -37,3 +37,9 @@ sub = **hh:hv:VanBik:Proto-Kuki-Chin**
 subrefs = 
 	**hh:hv:VanBik:Proto-Kuki-Chin**
 
+[iso_retirement]
+change_request = 2012-035
+effective = 2013-01-23 
+supersedes = 
+	yos
+

--- a/languoids/tree/sino1245/kuki1245/kuki1246/peri1260/nort3179/thad1239/puru1266/md.ini
+++ b/languoids/tree/sino1245/kuki1245/kuki1246/peri1260/nort3179/thad1239/puru1266/md.ini
@@ -19,3 +19,9 @@ sub = **hh:hv:VanBik:Proto-Kuki-Chin**
 subrefs = 
 	**hh:hv:VanBik:Proto-Kuki-Chin**
 
+[iso_retirement]
+change_request = 2013-008
+effective = 2014-02-03 
+supersedes = 
+	puz
+

--- a/languoids/tree/sino1245/kuki1245/kuki1246/peri1260/sout3160/pale1263/choa1238/mroc1235/md.ini
+++ b/languoids/tree/sino1245/kuki1245/kuki1246/peri1260/sout3160/pale1263/choa1238/mroc1235/md.ini
@@ -36,3 +36,9 @@ lgcode =
 [identifier]
 multitree = cmr
 
+[iso_retirement]
+change_request = 2011-037
+effective = 2012-02-03 
+supersedes = 
+	cka
+

--- a/languoids/tree/sino1245/kuki1245/naga1409/anga1312/aoic1235/yimc1239/maku1272/maku1273/md.ini
+++ b/languoids/tree/sino1245/kuki1245/naga1409/anga1312/aoic1235/yimc1239/maku1272/maku1273/md.ini
@@ -35,3 +35,9 @@ sub = **hh:typ:Shi:Makuri-Naga**
 subrefs = 
 	**hh:typ:Shi:Makuri-Naga**
 
+[iso_retirement]
+change_request = 2007-252
+effective = 2008-01-14 
+supersedes = 
+	nky
+

--- a/languoids/tree/sino1245/kuki1245/naga1409/anga1312/aoic1235/yimc1239/para1302/md.ini
+++ b/languoids/tree/sino1245/kuki1245/naga1409/anga1312/aoic1235/yimc1239/para1302/md.ini
@@ -37,3 +37,9 @@ sub = **hh:he:Saul:Naga-Burma**
 subrefs = 
 	**hh:he:Saul:Naga-Burma**
 
+[iso_retirement]
+change_request = 2007-252
+effective = 2008-01-14 
+supersedes = 
+	nky
+

--- a/languoids/tree/sino1245/macr1268/tani1259/prew1234/west2797/suba1255/bang1372/tagi1241/md.ini
+++ b/languoids/tree/sino1245/macr1268/tani1259/prew1234/west2797/suba1255/bang1372/tagi1241/md.ini
@@ -27,3 +27,9 @@ subrefs =
 [identifier]
 endangeredlanguages = 5696
 
+[iso_retirement]
+change_request = 2011-132
+effective = 2012-02-03 
+supersedes = 
+	dap
+

--- a/languoids/tree/sino1245/macr1268/tani1259/prew1234/west2797/suba1255/nyis1236/md.ini
+++ b/languoids/tree/sino1245/macr1268/tani1259/prew1234/west2797/suba1255/nyis1236/md.ini
@@ -31,3 +31,9 @@ sub = **hh:hv:Post:Defoliating-Tani**
 subrefs = 
 	**hh:hv:Post:Defoliating-Tani**
 
+[iso_retirement]
+change_request = 2011-132
+effective = 2012-02-03 
+supersedes = 
+	dap
+

--- a/languoids/tree/sout2845/ahkk1235/aari1238/aari1239/md.ini
+++ b/languoids/tree/sout2845/ahkk1235/aari1238/aari1239/md.ini
@@ -55,3 +55,9 @@ subrefs =
 	**hh:soc:Jordanetal:Gayil**
 	**hh:hvw:Tsuge:SOmotic**
 
+[iso_retirement]
+change_request = 2007-040
+effective = 2008-01-14 
+supersedes = 
+	aiz
+

--- a/languoids/tree/sout2845/ahkk1235/aari1238/gayi1237/md.ini
+++ b/languoids/tree/sout2845/ahkk1235/aari1238/gayi1237/md.ini
@@ -34,3 +34,9 @@ subrefs =
 	**hh:soc:Jordanetal:Gayil**
 	**hh:hvw:Tsuge:SOmotic**
 
+[iso_retirement]
+change_request = 2007-040
+effective = 2008-01-14 
+supersedes = 
+	aiz
+

--- a/languoids/tree/taik1256/kada1291/east2365/buya1244/nort2744/emab1235/md.ini
+++ b/languoids/tree/taik1256/kada1291/east2365/buya1244/nort2744/emab1235/md.ini
@@ -38,3 +38,9 @@ sub = **hh:hv:Ostapirat:Proto-Kra**
 subrefs = 
 	**hh:hv:Ostapirat:Proto-Kra**
 
+[iso_retirement]
+change_request = 2007-012
+effective = 2008-01-14 
+supersedes = 
+	byu
+

--- a/languoids/tree/taik1256/kada1291/east2365/buya1244/nort2744/lang1316/md.ini
+++ b/languoids/tree/taik1256/kada1291/east2365/buya1244/nort2744/lang1316/md.ini
@@ -40,3 +40,9 @@ sub = **hh:hv:Ostapirat:Proto-Kra**
 subrefs = 
 	**hh:hv:Ostapirat:Proto-Kra**
 
+[iso_retirement]
+change_request = 2007-012
+effective = 2008-01-14 
+supersedes = 
+	byu
+

--- a/languoids/tree/taik1256/kada1291/sout3143/paha1254/baha1256/md.ini
+++ b/languoids/tree/taik1256/kada1291/sout3143/paha1254/baha1256/md.ini
@@ -42,3 +42,9 @@ sub = **hh:hv:Edmondson:Kra**
 subrefs = 
 	**hh:hv:Edmondson:Kra**
 
+[iso_retirement]
+change_request = 2007-012
+effective = 2008-01-14 
+supersedes = 
+	byu
+

--- a/languoids/tree/taik1256/kada1291/sout3143/west2798/gela1265/nort3188/ahou1236/aoua1234/md.ini
+++ b/languoids/tree/taik1256/kada1291/sout3143/west2798/gela1265/nort3188/ahou1236/aoua1234/md.ini
@@ -19,3 +19,9 @@ sub = **hh:hv:Ostapirat:Proto-Kra**
 subrefs = 
 	**hh:hv:Ostapirat:Proto-Kra**
 
+[iso_retirement]
+change_request = 2011-054
+effective = 2012-02-03 
+supersedes = 
+	gio
+

--- a/languoids/tree/taik1256/kada1291/sout3143/west2798/gela1265/qaua1234/md.ini
+++ b/languoids/tree/taik1256/kada1291/sout3143/west2798/gela1265/qaua1234/md.ini
@@ -22,3 +22,9 @@ subrefs =
 [identifier]
 endangeredlanguages = 1511
 
+[iso_retirement]
+change_request = 2011-054
+effective = 2012-02-03 
+supersedes = 
+	gio
+

--- a/languoids/tree/taik1256/kamt1241/beta1258/daic1237/cent2251/deba1238/nong1247/md.ini
+++ b/languoids/tree/taik1256/kamt1241/beta1258/daic1237/cent2251/deba1238/nong1247/md.ini
@@ -47,3 +47,9 @@ sub = **hh:hv:Pittayaporn:Proto-Tai**:286-304 (called G)
 subrefs = 
 	**hh:hv:Pittayaporn:Proto-Tai**
 
+[iso_retirement]
+change_request = 2006-128
+effective = 2007-07-18 
+supersedes = 
+	ccy
+

--- a/languoids/tree/taik1256/kamt1241/beta1258/daic1237/cent2251/deba1238/yang1286/md.ini
+++ b/languoids/tree/taik1256/kamt1241/beta1258/daic1237/cent2251/deba1238/yang1286/md.ini
@@ -87,3 +87,9 @@ sub = **hh:hv:Pittayaporn:Proto-Tai**:286-304 (called G)
 subrefs = 
 	**hh:hv:Pittayaporn:Proto-Tai**
 
+[iso_retirement]
+change_request = 2006-128
+effective = 2007-07-18 
+supersedes = 
+	ccy
+

--- a/languoids/tree/taik1256/kamt1241/beta1258/daic1237/cent2251/wenm1239/daiz1235/md.ini
+++ b/languoids/tree/taik1256/kamt1241/beta1258/daic1237/cent2251/wenm1239/daiz1235/md.ini
@@ -51,3 +51,9 @@ sub = **hh:hv:Pittayaporn:Proto-Tai**:286-304 (called G)
 subrefs = 
 	**hh:hv:Pittayaporn:Proto-Tai**
 
+[iso_retirement]
+change_request = 2006-128
+effective = 2007-07-18 
+supersedes = 
+	ccy
+

--- a/languoids/tree/taik1256/kamt1241/beta1258/daic1237/cent2251/wenm1239/sapa1255/sout3184/sout2743/redt1235/taim1254/taid1248/md.ini
+++ b/languoids/tree/taik1256/kamt1241/beta1258/daic1237/cent2251/wenm1239/sapa1255/sout3184/sout2743/redt1235/taim1254/taid1248/md.ini
@@ -33,3 +33,9 @@ lexvo =
 [identifier]
 multitree = tyj
 
+[iso_retirement]
+change_request = 2015-019
+effective = 2016-01-15 
+supersedes = 
+	tmp
+

--- a/languoids/tree/taik1256/kamt1241/beta1258/daic1237/cent2251/wenm1239/sapa1255/sout3184/sout2743/redt1235/taim1254/taid1248/taim1250/md.ini
+++ b/languoids/tree/taik1256/kamt1241/beta1258/daic1237/cent2251/wenm1239/sapa1255/sout3184/sout2743/redt1235/taim1254/taid1248/taim1250/md.ini
@@ -47,3 +47,10 @@ lgcode =
 [identifier]
 multitree = tmp
 
+[iso_retirement]
+change_request = 2015-019
+remedy = Merge
+code = tmp
+name = Tai Mène
+effective = 2016-01-15 
+

--- a/languoids/tree/taik1256/kamt1241/beta1258/daic1237/cent2251/wenm1239/sapa1255/sout3184/sout2743/redt1235/taim1254/taip1250/md.ini
+++ b/languoids/tree/taik1256/kamt1241/beta1258/daic1237/cent2251/wenm1239/sapa1255/sout3184/sout2743/redt1235/taim1254/taip1250/md.ini
@@ -39,3 +39,9 @@ isohid = tpo
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18/E19
 
+[iso_retirement]
+change_request = 2015-018
+effective = 2016-01-15 
+supersedes = 
+	thc
+

--- a/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/nort3189/cent2009/md.ini
+++ b/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/nort3189/cent2009/md.ini
@@ -42,3 +42,9 @@ subrefs =
 	**hh:hv:Pittayaporn:Proto-Tai**
 	**hh:hv:EdmondsonSolnit:Kadai-Tai:Introduction**
 
+[iso_retirement]
+change_request = 2007-027
+effective = 2008-01-14 
+supersedes = 
+	ccx
+

--- a/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/nort3189/east2363/md.ini
+++ b/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/nort3189/east2363/md.ini
@@ -40,3 +40,9 @@ subrefs =
 	**hh:hv:Pittayaporn:Proto-Tai**
 	**hh:hv:EdmondsonSolnit:Kadai-Tai:Introduction**
 
+[iso_retirement]
+change_request = 2007-027
+effective = 2008-01-14 
+supersedes = 
+	ccx
+

--- a/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/nort3189/guib1244/md.ini
+++ b/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/nort3189/guib1244/md.ini
@@ -42,3 +42,9 @@ subrefs =
 	**hh:hv:Pittayaporn:Proto-Tai**
 	**hh:hv:EdmondsonSolnit:Kadai-Tai:Introduction**
 
+[iso_retirement]
+change_request = 2007-027
+effective = 2008-01-14 
+supersedes = 
+	ccx
+

--- a/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/nort3189/guib1245/md.ini
+++ b/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/nort3189/guib1245/md.ini
@@ -42,3 +42,9 @@ subrefs =
 	**hh:hv:Pittayaporn:Proto-Tai**
 	**hh:hv:EdmondsonSolnit:Kadai-Tai:Introduction**
 
+[iso_retirement]
+change_request = 2007-027
+effective = 2008-01-14 
+supersedes = 
+	ccx
+

--- a/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/nort3189/lian1252/md.ini
+++ b/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/nort3189/lian1252/md.ini
@@ -39,3 +39,9 @@ subrefs =
 	**hh:hv:Pittayaporn:Proto-Tai**
 	**hh:hv:EdmondsonSolnit:Kadai-Tai:Introduction**
 
+[iso_retirement]
+change_request = 2007-027
+effective = 2008-01-14 
+supersedes = 
+	ccx
+

--- a/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/nort3189/liuj1238/md.ini
+++ b/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/nort3189/liuj1238/md.ini
@@ -41,3 +41,9 @@ subrefs =
 	**hh:hv:Pittayaporn:Proto-Tai**
 	**hh:hv:EdmondsonSolnit:Kadai-Tai:Introduction**
 
+[iso_retirement]
+change_request = 2007-027
+effective = 2008-01-14 
+supersedes = 
+	ccx
+

--- a/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/nort3189/liuq1235/md.ini
+++ b/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/nort3189/liuq1235/md.ini
@@ -39,3 +39,9 @@ subrefs =
 	**hh:hv:Pittayaporn:Proto-Tai**
 	**hh:hv:EdmondsonSolnit:Kadai-Tai:Introduction**
 
+[iso_retirement]
+change_request = 2007-027
+effective = 2008-01-14 
+supersedes = 
+	ccx
+

--- a/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/nort3189/qiub1238/md.ini
+++ b/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/nort3189/qiub1238/md.ini
@@ -41,3 +41,9 @@ subrefs =
 	**hh:hv:Pittayaporn:Proto-Tai**
 	**hh:hv:EdmondsonSolnit:Kadai-Tai:Introduction**
 
+[iso_retirement]
+change_request = 2007-027
+effective = 2008-01-14 
+supersedes = 
+	ccx
+

--- a/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/nort3189/youj1238/md.ini
+++ b/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/nort3189/youj1238/md.ini
@@ -41,3 +41,9 @@ subrefs =
 	**hh:hv:Pittayaporn:Proto-Tai**
 	**hh:hv:EdmondsonSolnit:Kadai-Tai:Introduction**
 
+[iso_retirement]
+change_request = 2007-027
+effective = 2008-01-14 
+supersedes = 
+	ccx
+

--- a/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/yong1274/yong1275/md.ini
+++ b/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/yong1274/yong1275/md.ini
@@ -77,3 +77,9 @@ subrefs =
 	**hh:hv:Pittayaporn:Proto-Tai**
 	**hh:hv:EdmondsonSolnit:Kadai-Tai:Introduction**
 
+[iso_retirement]
+change_request = 2006-128
+effective = 2007-07-18 
+supersedes = 
+	ccy
+

--- a/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/yong1274/yong1276/md.ini
+++ b/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/yong1274/yong1276/md.ini
@@ -47,3 +47,9 @@ subrefs =
 	**hh:hv:Pittayaporn:Proto-Tai**
 	**hh:hv:EdmondsonSolnit:Kadai-Tai:Introduction**
 
+[iso_retirement]
+change_request = 2007-027
+effective = 2008-01-14 
+supersedes = 
+	ccx
+

--- a/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/zuoj1238/md.ini
+++ b/languoids/tree/taik1256/kamt1241/beta1258/daic1237/nort3180/zuoj1238/md.ini
@@ -51,3 +51,9 @@ subrefs =
 	**hh:hv:Pittayaporn:Proto-Tai**
 	**hh:hv:EdmondsonSolnit:Kadai-Tai:Introduction**
 
+[iso_retirement]
+change_request = 2006-128
+effective = 2007-07-18 
+supersedes = 
+	ccy
+

--- a/languoids/tree/toto1251/toto1252/cent1397/nort3265/tecp1235/md.ini
+++ b/languoids/tree/toto1251/toto1252/cent1397/nort3265/tecp1235/md.ini
@@ -36,3 +36,9 @@ sub = **hh:hv:Moore:Coahuitlan-Totonac**
 subrefs = 
 	**hh:hv:Moore:Coahuitlan-Totonac**
 
+[iso_retirement]
+change_request = 2006-085
+effective = 2007-07-18 
+supersedes = 
+	tot
+

--- a/languoids/tree/toto1251/toto1252/cent1397/nort3265/uppe1275/md.ini
+++ b/languoids/tree/toto1251/toto1252/cent1397/nort3265/uppe1275/md.ini
@@ -40,3 +40,9 @@ sub = **hh:hv:Moore:Coahuitlan-Totonac**
 subrefs = 
 	**hh:hv:Moore:Coahuitlan-Totonac**
 
+[iso_retirement]
+change_request = 2006-085
+effective = 2007-07-18 
+supersedes = 
+	tot
+

--- a/languoids/tree/tura1263/tura1264/bari1298/md.ini
+++ b/languoids/tree/tura1263/tura1264/bari1298/md.ini
@@ -31,3 +31,9 @@ sub = **hh:hv:Franklin:Other**:263-267
 subrefs = 
 	**hh:hv:Franklin:Other**
 
+[iso_retirement]
+change_request = 2011-081
+effective = 2012-02-03 
+supersedes = 
+	mgx
+

--- a/languoids/tree/tura1263/tura1264/mouw1234/md.ini
+++ b/languoids/tree/tura1263/tura1264/mouw1234/md.ini
@@ -22,3 +22,9 @@ sub = **hh:hv:Franklin:Other**:263-267
 subrefs = 
 	**hh:hv:Franklin:Other**
 
+[iso_retirement]
+change_request = 2011-081
+effective = 2012-02-03 
+supersedes = 
+	mgx
+

--- a/languoids/tree/unat1236/afro1259/daza1244/md.ini
+++ b/languoids/tree/unat1236/afro1259/daza1244/md.ini
@@ -39,3 +39,10 @@ isohid = dzd
 comment_type = Spurious
 ethnologue_versions = E16/E17
 
+[iso_retirement]
+change_request = 2014-029
+remedy = Retire
+code = dzd
+name = Daza
+effective = 2015-01-12 
+

--- a/languoids/tree/unat1236/cari1285/kara1475/md.ini
+++ b/languoids/tree/unat1236/cari1285/kara1475/md.ini
@@ -45,3 +45,10 @@ isohid = xkh
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-038
+remedy = Retire
+code = xkh
+name = Karahawyana
+effective = 2016-01-15 
+

--- a/languoids/tree/unat1236/choc1284/runa1235/md.ini
+++ b/languoids/tree/unat1236/choc1284/runa1235/md.ini
@@ -32,3 +32,10 @@ isohid = rna
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-023
+remedy = Retire
+code = rna
+name = Runa
+effective = 2016-01-15 
+

--- a/languoids/tree/unat1236/namb1301/alap1235/md.ini
+++ b/languoids/tree/unat1236/namb1301/alap1235/md.ini
@@ -19,3 +19,9 @@ glottolog =
 lexvo = 
 	Alapmunte [en]
 
+[iso_retirement]
+change_request = 2007-017
+effective = 2008-01-14 
+supersedes = 
+	mbg
+

--- a/languoids/tree/unat1236/namb1301/yala1242/md.ini
+++ b/languoids/tree/unat1236/namb1301/yala1242/md.ini
@@ -31,3 +31,9 @@ lexvo =
 [identifier]
 multitree = xyl
 
+[iso_retirement]
+change_request = 2007-017
+effective = 2008-01-14 
+supersedes = 
+	mbg
+

--- a/languoids/tree/unat1236/palu1237/md.ini
+++ b/languoids/tree/unat1236/palu1237/md.ini
@@ -35,3 +35,10 @@ isohid = pmc
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-040
+remedy = Retire
+code = pmc
+name = Palumata
+effective = 2016-01-15 
+

--- a/languoids/tree/unat1236/pano1260/shin1267/md.ini
+++ b/languoids/tree/unat1236/pano1260/shin1267/md.ini
@@ -31,3 +31,10 @@ isohid = snh
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18/E19
 
+[iso_retirement]
+change_request = 2016-004
+remedy = Retire
+code = snh
+name = Shinabo
+effective = 2017-01-31 
+

--- a/languoids/tree/unat1236/pano1260/xipi1238/md.ini
+++ b/languoids/tree/unat1236/pano1260/xipi1238/md.ini
@@ -35,3 +35,10 @@ isohid = xip
 comment_type = Spurious
 ethnologue_versions = E16/E17/E18
 
+[iso_retirement]
+change_request = 2015-011
+remedy = Retire
+code = xip
+name = Xipináwa
+effective =  
+

--- a/languoids/tree/uncl1493/pija1235/md.ini
+++ b/languoids/tree/uncl1493/pija1235/md.ini
@@ -38,3 +38,10 @@ lgcode =
 [identifier]
 multitree = pij
 
+[iso_retirement]
+change_request = 2015-042
+effective = 2016-01-15 
+supersedes = 
+	coy
+	nts
+

--- a/languoids/tree/utoa1244/sout3136/cora1261/azte1234/east2720/tehu1243/tehu1244/sier1248/md.ini
+++ b/languoids/tree/utoa1244/sout3136/cora1261/azte1234/east2720/tehu1243/tehu1244/sier1248/md.ini
@@ -36,3 +36,9 @@ sub = **hh:hv:Hill:Uto-Aztecan**
 subrefs = 
 	**hh:hv:Hill:Uto-Aztecan**
 
+[iso_retirement]
+change_request = 2006-089
+effective = 2007-07-18 
+supersedes = 
+	nhs
+

--- a/languoids/tree/utoa1244/sout3136/cora1261/azte1234/east2720/tehu1243/tehu1244/sout2973/md.ini
+++ b/languoids/tree/utoa1244/sout3136/cora1261/azte1234/east2720/tehu1243/tehu1244/sout2973/md.ini
@@ -48,3 +48,9 @@ sub = **hh:hv:Hill:Uto-Aztecan**
 subrefs = 
 	**hh:hv:Hill:Uto-Aztecan**
 
+[iso_retirement]
+change_request = 2006-089
+effective = 2007-07-18 
+supersedes = 
+	nhs
+

--- a/languoids/tree/utoa1244/sout3136/cora1261/azte1234/east2720/tehu1243/tehu1244/zaca1241/md.ini
+++ b/languoids/tree/utoa1244/sout3136/cora1261/azte1234/east2720/tehu1243/tehu1244/zaca1241/md.ini
@@ -53,3 +53,9 @@ sub = **hh:hv:Hill:Uto-Aztecan**
 subrefs = 
 	**hh:hv:Hill:Uto-Aztecan**
 
+[iso_retirement]
+change_request = 2006-101
+effective = 2007-07-18 
+supersedes = 
+	nhj
+

--- a/languoids/tree/utoa1244/sout3136/cora1261/azte1234/west2809/west2814/west2825/dura1246/east2695/md.ini
+++ b/languoids/tree/utoa1244/sout3136/cora1261/azte1234/west2809/west2814/west2825/dura1246/east2695/md.ini
@@ -21,3 +21,9 @@ sub = **hh:ldsoc:Canger:Nahuatl-Durango-Nayarit**
 subrefs = 
 	**hh:ldsoc:Canger:Nahuatl-Durango-Nayarit**
 
+[iso_retirement]
+change_request = 2011-111
+effective = 2012-02-03 
+supersedes = 
+	nln
+

--- a/languoids/tree/utoa1244/sout3136/cora1261/azte1234/west2809/west2814/west2825/dura1246/west2778/md.ini
+++ b/languoids/tree/utoa1244/sout3136/cora1261/azte1234/west2809/west2814/west2825/dura1246/west2778/md.ini
@@ -19,3 +19,9 @@ sub = **hh:ldsoc:Canger:Nahuatl-Durango-Nayarit**
 subrefs = 
 	**hh:ldsoc:Canger:Nahuatl-Durango-Nayarit**
 
+[iso_retirement]
+change_request = 2011-111
+effective = 2012-02-03 
+supersedes = 
+	nln
+

--- a/languoids/tree/waka1280/sout2981/noot1238/diti1235/md.ini
+++ b/languoids/tree/waka1280/sout2981/noot1238/diti1235/md.ini
@@ -39,3 +39,9 @@ subrefs =
 [identifier]
 endangeredlanguages = 1716
 
+[iso_retirement]
+change_request = 2010-033
+effective = 2011-05-18 
+supersedes = 
+	noo
+

--- a/languoids/tree/waka1280/sout2981/noot1238/nuuc1236/md.ini
+++ b/languoids/tree/waka1280/sout2981/noot1238/nuuc1236/md.ini
@@ -31,3 +31,9 @@ subrefs =
 [identifier]
 endangeredlanguages = 1717
 
+[iso_retirement]
+change_request = 2010-033
+effective = 2011-05-18 
+supersedes = 
+	noo
+

--- a/languoids/tree/wint1258/patw1250/md.ini
+++ b/languoids/tree/wint1258/patw1250/md.ini
@@ -27,3 +27,9 @@ ethnologue_versions = E16
 [identifier]
 endangeredlanguages = 1537
 
+[iso_retirement]
+change_request = 2012-144
+effective = 2013-01-23 
+supersedes = 
+	wit
+

--- a/languoids/tree/wint1258/wint1259/noml1242/md.ini
+++ b/languoids/tree/wint1258/wint1259/noml1242/md.ini
@@ -9,3 +9,9 @@ iso639-3 = nol
 hid = nol
 status = Extinct
 
+[iso_retirement]
+change_request = 2012-144
+effective = 2013-01-23 
+supersedes = 
+	wit
+

--- a/languoids/tree/wint1258/wint1259/nucl1651/md.ini
+++ b/languoids/tree/wint1258/wint1259/nucl1651/md.ini
@@ -11,3 +11,9 @@ longitude = -122.5
 latitude = 41.0
 status = Extinct
 
+[iso_retirement]
+change_request = 2012-144
+effective = 2013-01-23 
+supersedes = 
+	wit
+

--- a/languoids/tree/worr1236/west2435/ungg1243/md.ini
+++ b/languoids/tree/worr1236/west2435/ungg1243/md.ini
@@ -35,3 +35,9 @@ subrefs =
 [identifier]
 endangeredlanguages = 6726
 
+[iso_retirement]
+change_request = 2011-091
+effective = 2012-02-03 
+supersedes = 
+	unp
+

--- a/languoids/tree/worr1236/west2435/worr1237/md.ini
+++ b/languoids/tree/worr1236/west2435/worr1237/md.ini
@@ -42,3 +42,9 @@ subrefs =
 [identifier]
 endangeredlanguages = 2588
 
+[iso_retirement]
+change_request = 2011-091
+effective = 2012-02-03 
+supersedes = 
+	unp
+

--- a/pyglottolog/commands.py
+++ b/pyglottolog/commands.py
@@ -37,8 +37,9 @@ def htmlmap(args):
     for n in nodes.values():
         if n.level == Level.language and n.latitude != None:
             fid = n.lineage[0][1] if n.lineage else n.id
-            langs.append((n, fid))
-            legend.update([fid])
+            if not nodes[fid].category.startswith('Pseudo'):
+                langs.append((n, fid))
+                legend.update([fid])
 
     color_map = {fid: "{0:0{1}X}".format((i + 1) * 10, 3)
                  for i, fid in enumerate(sorted(legend.keys()))}
@@ -90,7 +91,7 @@ def htmlmap(args):
     write_text(
         html,
         rendered_template(
-            'htmlmap.html', version=git_describe(args.repos.repos), jsname=jsname))
+            'htmlmap.html', version=git_describe(args.repos.repos), jsname=jsname, nlangs=len(langs)))
     print(html.resolve().as_uri())
 
 
@@ -142,6 +143,13 @@ def isobib(args):  # pragma: no cover
     """Update iso6393.bib - the file of references for ISO 639-3 change requests.
     """
     pyglottolog.iso.bibtex(args.repos, args.log)
+
+
+@command()
+def isoretirements(args):  # pragma: no cover
+    """Update iso6393.bib - the file of references for ISO 639-3 change requests.
+    """
+    pyglottolog.iso.retirements(args.repos, args.log)
 
 
 def existing_lang(args):

--- a/pyglottolog/objects.py
+++ b/pyglottolog/objects.py
@@ -221,13 +221,14 @@ class ClassificationComment(object):
 
 @attr.s
 class ISORetirement(object):
-    code = attr.ib()
-    comment = attr.ib(convert=lambda s: s.replace('\n.', '\n'))
-    name = attr.ib()
-    effective = attr.ib()
+    code = attr.ib(default=None)
+    comment = attr.ib(convert=lambda s: s.replace('\n.', '\n') if s else s, default=None)
+    name = attr.ib(default=None)
+    effective = attr.ib(default=None)
     reason = attr.ib(default=None)
     remedy = attr.ib(default=None)
     change_request = attr.ib(default=None)
+    supersedes = attr.ib(default=attr.Factory(list))
 
     def asdict(self):
         return attr.asdict(self)

--- a/pyglottolog/templates/htmlmap/htmlmap.html
+++ b/pyglottolog/templates/htmlmap/htmlmap.html
@@ -17,7 +17,7 @@
     </head>
     <body>
         <h1>Glottolog $version: Languages</h1>
-        <p>All geo-referenced <a href="http://glottolog.org">Glottolog</a> languages color-coded by top-level family.</p>
+        <p>All $nlangs geo-referenced <a href="http://glottolog.org">Glottolog</a> languages color-coded by top-level family.</p>
         <div id='map'></div>
         <script src="$jsname" type="text/javascript"></script>
     </body>


### PR DESCRIPTION
Note: The following ISO codes figuring in adopted ISO 639-3 change requests are missing from Glottolog:
- Missing active ISO code: ylb
```python
{u'': u'more ...', u'Affected Identifier': u'ylb', u'Region': u'Pacific', u'Language Family': u'Oceanic', u'Language Name': u'\r\n\t\t\tYaleba\r\n\t\t', u'Change Type': u'Create', u'Outcome/Effective date': u'Adopted2010-01-18 ', u'CR Number': u'2009-045'}
```
- Missing active ISO code: ebk
```python
{u'': u'more ...', u'Affected Identifier': u'ebk', u'Region': u'Asia, Southeast', u'Language Family': u'Philippine', u'Language Name': u'\r\n\t\t\tEastern Bontok\r\n\t\t', u'Change Type': u'Create', u'Outcome/Effective date': u'Adopted2010-01-18 ', u'CR Number': u'2009-073'}
```
- Missing active ISO code: obk
```python
{u'': u'more ...', u'Affected Identifier': u'obk', u'Region': u'Asia, Southeast', u'Language Family': u'Philippine', u'Language Name': u'\r\n\t\t\tSouthern Bontok\r\n\t\t', u'Change Type': u'Create', u'Outcome/Effective date': u'Adopted2010-01-18 ', u'CR Number': u'2009-073'}
```
- Missing active ISO code: fbl
```python
{u'': u'more ...', u'Affected Identifier': u'fbl', u'Region': u'Asia, Southeast', u'Language Family': u'Philippine', u'Language Name': u'\r\n\t\t\tWest Albay Bikol\r\n\t\t', u'Change Type': u'Create', u'Outcome/Effective date': u'Adopted2010-01-18 ', u'CR Number': u'2009-078'}
```
- Missing active ISO code: rbl
```python
{u'': u'more ...', u'Affected Identifier': u'rbl', u'Region': u'Asia, Southeast', u'Language Family': u'Philippine', u'Language Name': u'\r\n\t\t\tMiraya Bikol\r\n\t\t', u'Change Type': u'Create', u'Outcome/Effective date': u'Adopted2010-01-18 ', u'CR Number': u'2009-078'}
```
- Missing active ISO code: jkp
```python
{u'': u'more ...', u'Affected Identifier': u'jkp', u'Region': u'Asia, Southeast', u'Language Family': u'Tibeto-Burman', u'Language Name': u'\r\n\t\t\tPaku Karen\r\n\t\t', u'Change Type': u'Create', u'Outcome/Effective date': u'Adopted2012-02-03 ', u'CR Number': u'2011-059'}
```
- Missing active ISO code: dgl
```python
{u'': u'more ...', u'Affected Identifier': u'dgl', u'Region': u'Africa, North', u'Language Family': u'Eastern Sudanic', u'Language Name': u'\r\n\t\t\tAndaandi\r\n\t\t', u'Change Type': u'Create', u'Outcome/Effective date': u'Adopted2012-02-03 ', u'CR Number': u'2011-143'}
```
- Missing active ISO code: xnz
```python
{u'': u'more ...', u'Affected Identifier': u'xnz', u'Region': u'Africa, North', u'Language Family': u'Eastern Sudanic', u'Language Name': u'\r\n\t\t\tKenzi\r\n\t\t', u'Change Type': u'Create', u'Outcome/Effective date': u'Adopted2012-02-03 ', u'CR Number': u'2011-143'}
```
- Missing active ISO code: wnn
```python
{u'': u'more ...', u'Affected Identifier': u'wnn', u'Region': u'Pacific', u'Language Family': u'Australian', u'Language Name': u'\r\n\t\t\tWunumara\r\n\t\t', u'Change Type': u'Create', u'Outcome/Effective date': u'Adopted2013-01-23 ', u'CR Number': u'2012-007'}
```
- Missing active ISO code: dmw
```python
{u'': u'more ...', u'Affected Identifier': u'dmw', u'Region': u'Pacific', u'Language Family': u'Australian', u'Language Name': u'\r\n\t\t\tMudburra\r\n\t\t', u'Change Type': u'Create', u'Outcome/Effective date': u'Adopted2013-01-23 ', u'CR Number': u'2012-073'}
```
- Missing active ISO code: xrq
```python
{u'': u'more ...', u'Affected Identifier': u'xrq', u'Region': u'Pacific', u'Language Family': u'Australian', u'Language Name': u'\r\n\t\t\tKarranga\r\n\t\t', u'Change Type': u'Create', u'Outcome/Effective date': u'Adopted2013-01-23 ', u'CR Number': u'2012-073'}
```
- Missing active ISO code: ekc
```python
{u'': u'more ...', u'Affected Identifier': u'ekc', u'Region': u'Pacific', u'Language Family': u'Australian', u'Language Name': u'\r\n\t\t\tEastern Karnic\r\n\t\t', u'Change Type': u'Create', u'Outcome/Effective date': u'Adopted2013-01-23 ', u'CR Number': u'2012-077'}
```
- Missing active ISO code: enl
```python
{u'': u'more ...', u'Affected Identifier': u'enl', u'Region': u'America, South', u'Language Family': u'Mascoian', u'Language Name': u'\r\n\t\t\tEnlhet\r\n\t\t', u'Change Type': u'Create', u'Outcome/Effective date': u'Adopted2014-02-03 ', u'CR Number': u'2013-014'}
```
- Missing active ISO code: enx
```python
{u'': u'more ...', u'Affected Identifier': u'enx', u'Region': u'America, South', u'Language Family': u'Mascoian', u'Language Name': u'\r\n\t\t\tEnxet\r\n\t\t', u'Change Type': u'Create', u'Outcome/Effective date': u'Adopted2014-02-03 ', u'CR Number': u'2013-014'}
```
- Missing retired ISO code: ymt
```python
{u'': u'more ...', u'Affected Identifier': u'ymt', u'Region': u'Asia, Central', u'Language Family': u'Uralic', u'Language Name': u'\r\n\t\t\tMator-Taygi-Karagas\r\n\t\t', u'Change Type': u'Retire', u'Outcome/Effective date': u'Adopted2015-01-12 ', u'CR Number': u'2014-003'}
```
- Missing retired ISO code: gfx
```python
{u'': u'more ...', u'Affected Identifier': u'gfx', u'Region': u'Africa, Southern', u'Language Family': u'Khoisan', u'Language Name': u'\r\n\t\t\tMangetti Dune !Xung\r\n\t\t', u'Change Type': u'Merge', u'Outcome/Effective date': u'Adopted2015-01-12 ', u'CR Number': u'2014-057'}
```
- Missing active ISO code: dwu
```python
{u'': u'more ...', u'Affected Identifier': u'dwu', u'Region': u'Pacific', u'Language Family': u'Australian', u'Language Name': u'\r\n\t\t\tDhuwal\r\n\t\t', u'Change Type': u'Create', u'Outcome/Effective date': u'Adopted2016-01-15 ', u'CR Number': u'2015-053'}
```
- Missing active ISO code: dwy
```python
{u'': u'more ...', u'Affected Identifier': u'dwy', u'Region': u'Pacific', u'Language Family': u'Australian', u'Language Name': u'\r\n\t\t\tDhuwaya\r\n\t\t', u'Change Type': u'Create', u'Outcome/Effective date': u'Adopted2016-01-15 ', u'CR Number': u'2015-053'}
```
- Missing retired ISO code: kgc
```python
{u'': u'more ...', u'Affected Identifier': u'kgc', u'Region': u'Asia, Southeast', u'Language Family': u'Mon-Khmer', u'Language Name': u'\r\n\t\t\tKasseng\r\n\t\t', u'Change Type': u'Retire', u'Outcome/Effective date': u'Adopted ', u'CR Number': u'2015-057'}
```
- Missing active ISO code: esg
```python
{u'': u'more ...', u'Affected Identifier': u'esg', u'Region': u'Asia, South', u'Language Family': u'Dravidian', u'Language Name': u'\r\n\t\t\tAheri Gondi\r\n\t\t', u'Change Type': u'Create', u'Outcome/Effective date': u'Adopted2016-01-15 ', u'CR Number': u'2015-062'}
```
- Missing active ISO code: wsg
```python
{u'': u'more ...', u'Affected Identifier': u'wsg', u'Region': u'Asia, South', u'Language Family': u'Dravidian', u'Language Name': u'\r\n\t\t\tAdilabad Gondi\r\n\t\t', u'Change Type': u'Create', u'Outcome/Effective date': u'Adopted2016-01-15 ', u'CR Number': u'2015-062'}
```
- Missing active ISO code: ilm
```python
{u'': u'more ...', u'Affected Identifier': u'ilm', u'Region': u'Asia, Southeast', u'Language Family': u'Philippine', u'Language Name': u'\r\n\t\t\tIranun (Malaysia)\r\n\t\t', u'Change Type': u'Create', u'Outcome/Effective date': u'Adopted2016-01-15 ', u'CR Number': u'2015-067'}
```
- Missing active ISO code: ilp
```python
{u'': u'more ...', u'Affected Identifier': u'ilp', u'Region': u'Asia, Southeast', u'Language Family': u'Philippine', u'Language Name': u'\r\n\t\t\tIranun (Philippines)\r\n\t\t', u'Change Type': u'Create', u'Outcome/Effective date': u'Adopted2016-01-15 ', u'CR Number': u'2015-067'}
```