### PR TITLE
remove underscore from iwai1249 name

### DIFF
--- a/languoids/tree/aust1307/mala1545/cent2237/east2712/ocea1241/sout3173/newc1243/extr1244/nyal1256/nyal1254/bele1250/md.ini
+++ b/languoids/tree/aust1307/mala1545/cent2237/east2712/ocea1241/sout3173/newc1243/extr1244/nyal1256/nyal1254/bele1250/md.ini
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 [core]
-name = Belep Properly
+name = Belep Proper
 level = dialect
 macroareas = 
 	Papunesia

--- a/languoids/tree/unat1236/iwai1249/md.ini
+++ b/languoids/tree/unat1236/iwai1249/md.ini
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 [core]
-name = Iwaidjan_Proper (Unattested)
+name = Iwaidjan Proper (Unattested)
 level = family
 


### PR DESCRIPTION
I started to move our checks from [glottolog3](https://github.com/clld/glottolog3/blob/52832bf634b2ee85e2f382317f7b227e405e3499/glottolog3/scripts/check_db_consistency.py) here:
https://github.com/clld/glottolog/blob/master/scripts/treedb.py#L747-L817
Assuming they are still valid, the underscore should be avoided.

Just to make sure: Is [Belep Properly](http://glottolog.org/resource/languoid/id/bele1250) intended as is?
```sql
SELECT l.id, l.name, l.level, f.path
FROM languoid AS l JOIN _file AS f ON f.path LIKE '%' || l.id
WHERE l.name LIKE '%proper%'
ORDER BY l.id

id       |name                         |level   |path                                                                                                                 |
---------|-----------------------------|--------|---------------------------------------------------------------------------------------------------------------------|
alta1277 |Altai Proper                 |dialect |turk1311/comm1245/kipc1239/east2791/sout2694/alta1277                                                                |
bang1336 |Bangaru Proper               |dialect |indo1319/indo1320/indo1321/indo1322/subc1234/west2812/hary1238/bang1336                                              |
bele1250 |Belep Properly               |dialect |aust1307/mala1545/cent2237/east2712/ocea1241/sout3173/newc1243/extr1244/nyal1256/nyal1254/bele1250                   |
bina1278 |Binandere Proper             |dialect |nucl1709/bina1276/bina1279/nucl1603/bina1277/bina1278                                                                |
chha1250 |Chhattisgarhi Proper         |dialect |indo1319/indo1320/indo1321/indo1322/subc1234/east2726/chha1249/chha1250                                              |
fuln1248 |Fulniô Proper                |dialect |fuln1247/fuln1248                                                                                                    |
hert1242 |Hértevin Proper              |dialect |afro1255/semi1276/west2786/cent2236/nort3165/aram1259/east2680/cent2217/boht1239/hert1241/hert1242                   |
iwai1246 |Iwaidjan Proper              |family  |iwai1246                                                                                                             |
iwai1249 |Iwaidjan_Proper (Unattested) |family  |unat1236/iwai1249                                                                                                    |
kana1282 |Kanauji Proper               |dialect |indo1319/indo1320/indo1321/indo1322/subc1234/west2812/kana1281/kana1282                                              |
kash1275 |Kashubian Proper             |dialect |indo1319/balt1263/slav1255/west2792/lech1241/kash1274/kash1275                                                       |
malv1244 |Malvi Proper                 |dialect |indo1319/indo1320/indo1321/indo1322/subc1234/bhil1254/malv1243/malv1244                                              |
panj1257 |Panjabi Proper               |dialect |indo1319/indo1320/indo1321/indo1324/sind1278/east2727/panj1256/panj1257                                              |
tini1247 |Tinigua Proper               |dialect |tini1245/tini1247                                                                                                    |
vene1259 |Venetian Proper              |dialect |indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1279/vene1258/vene1259 |
```
