### PR TITLE
Correcting geocoordinates

### DIFF
--- a/languoids/tree/aust1307/mala1545/cent2237/east2712/ocea1241/temo1244/utup1237/vano1237/md.ini
+++ b/languoids/tree/aust1307/mala1545/cent2237/east2712/ocea1241/temo1244/utup1237/vano1237/md.ini
@@ -4,8 +4,8 @@ name = Vano
 hid = vnk
 level = language
 iso639-3 = vnk
-latitude = -10.6865
-longitude = 165.927
+latitude = -11.6107
+longitude = 166.7984
 macroareas = 
 	Papunesia
 countries = 


### PR DESCRIPTION
The language Vano was assigned to the wrong island.  It's a language of Vanikoro I., traditionally in NW area.  Was down to 4 speakers in my last field trip of 2012;  so yes, it's a moribund language for sure. See http://alex.francois.online.fr/AF-maps-Vanikoro.htm 
(I'll make a separate commit to propose renaming it to "Lovono".)