### PR TITLE
Changing lg name

### DIFF
--- a/languoids/tree/aust1307/mala1545/cent2237/east2712/ocea1241/temo1244/utup1237/vano1237/md.ini
+++ b/languoids/tree/aust1307/mala1545/cent2237/east2712/ocea1241/temo1244/utup1237/vano1237/md.ini
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 [core]
-name = Vano
+name = Lovono
 hid = vnk
 level = language
 iso639-3 = vnk


### PR DESCRIPTION
The name "Vano" is not recognised by modern speakers.  The native name is "Alavana", but being a moribund language, very few people recognise that form either.  The common way to refer to the language is "Lovono", i.e. the same placename as it is named in the main island's sole surviving language Teanu.  I therefore propose to rename it "Lovono". See http://alex.francois.online.fr/AF-maps-Vanikoro.htm 

(I made a separate change about its spatial coordinates;  I'm not well used to GitHub, so I'm not sure this is the best way to proceed. The risk, by accepting this latest version, is to get back to the wrong coordinates. 
Should I have done all my edits in a single pull request?)