### PR TITLE
Correction

### DIFF
--- a/languoids/tree/indo1319/indo1320/indo1321/indo1323/oriy1254/gaud1237/gaud1238/beng1280/cent1983/md.ini
+++ b/languoids/tree/indo1319/indo1320/indo1321/indo1323/oriy1254/gaud1237/gaud1238/beng1280/cent1983/md.ini
@@ -10,7 +10,8 @@ countries =
 multitree = 
 	Central Bengali
 	Central Standard Bengali
-
+        Rarhi
+	
 [identifier]
 multitree = ben-cen
 


### PR DESCRIPTION
The dialect, named 'Central Bengali' is also called 'Rarhi'.