### PR TITLE
Kala Lagaw Ya is better as an Australian language than Papuan?

### DIFF
--- a/languoids/tree/pama1250/kala1377/md.ini
+++ b/languoids/tree/pama1250/kala1377/md.ini
@@ -7,7 +7,7 @@ iso639-3 = mwp
 latitude = -10.6748
 longitude = 142.196
 macroareas = 
-	Papunesia
+	Australia
 countries = 
 	Australia (AU)
 


### PR DESCRIPTION
It is definitely a borderline case (almost literally), but given that it's (a) closer to Australia than Papuanesia, and (b) is primarily Pama-Nyungan, I think it should be Australian. 