### PR TITLE
deprecation warnings suck

### DIFF
--- a/pyglottolog/references/bibtex.py
+++ b/pyglottolog/references/bibtex.py
@@ -83,9 +83,8 @@ class Name(collections.namedtuple('Name', 'prelast last given lineage')):
     @classmethod
     def from_string(cls, name):
         person = Person(name)
-        prelast, last, first, middle, lineage = (
-            ' '.join(getattr(person, part)())
-            for part in ('prelast', 'last', 'first', 'middle', 'lineage'))
+        ntypes = ('prelast_names', 'last_names', 'first_names', 'middle_names', 'lineage_names')
+        prelast, last, first, middle, lineage = (' '.join(getattr(person, part)) for part in ntypes)
         given = ' '.join(n for n in (first, middle) if n)
         return cls(prelast, last, given, lineage)
 


### PR DESCRIPTION
```
...glottolog/.tox/py36/lib/python3.6/site-packages/pyglottolog/references/bibtex.py:88: DeprecationWarning: prelast() is deprecated since 0.19: use Person.prelast_names instead
  for part in ('prelast', 'last', 'first', 'middle', 'lineage'))
...glottolog/.tox/py36/lib/python3.6/site-packages/pyglottolog/references/bibtex.py:88: DeprecationWarning: last() is deprecated since 0.19: use Person.last_names instead
  for part in ('prelast', 'last', 'first', 'middle', 'lineage'))
...glottolog/.tox/py36/lib/python3.6/site-packages/pyglottolog/references/bibtex.py:88: DeprecationWarning: first() is deprecated since 0.19: use Person.first_names instead
  for part in ('prelast', 'last', 'first', 'middle', 'lineage'))
...glottolog/.tox/py36/lib/python3.6/site-packages/pyglottolog/references/bibtex.py:88: DeprecationWarning: middle() is deprecated since 0.19: use Person.middle_names instead
  for part in ('prelast', 'last', 'first', 'middle', 'lineage'))
...glottolog/.tox/py36/lib/python3.6/site-packages/pyglottolog/references/bibtex.py:88: DeprecationWarning: lineage() is deprecated since 0.19: use Person.lineage_names instead
  for part in ('prelast', 'last', 'first', 'middle', 'lineage'))
...glottolog/.tox/py36/lib/python3.6/site-packages/pyglottolog/references/bibtex.py:88: DeprecationWarning: prelast() is deprecated since 0.19: use Person.prelast_names instead
  for part in ('prelast', 'last', 'first', 'middle', 'lineage'))
...glottolog/.tox/py36/lib/python3.6/site-packages/pyglottolog/references/bibtex.py:88: DeprecationWarning: last() is deprecated since 0.19: use Person.last_names instead
  for part in ('prelast', 'last', 'first', 'middle', 'lineage'))
...glottolog/.tox/py36/lib/python3.6/site-packages/pyglottolog/references/bibtex.py:88: DeprecationWarning: first() is deprecated since 0.19: use Person.first_names instead
  for part in ('prelast', 'last', 'first', 'middle', 'lineage'))
...glottolog/.tox/py36/lib/python3.6/site-packages/pyglottolog/references/bibtex.py:88: DeprecationWarning: middle() is deprecated since 0.19: use Person.middle_names instead
  for part in ('prelast', 'last', 'first', 'middle', 'lineage'))
...glottolog/.tox/py36/lib/python3.6/site-packages/pyglottolog/references/bibtex.py:88: DeprecationWarning: lineage() is deprecated since 0.19: use Person.lineage_names instead
  for part in ('prelast', 'last', 'first', 'middle', 'lineage'))
```