### PR TITLE
Implement Template for newick_node

### DIFF
--- a/pyglottolog/api.py
+++ b/pyglottolog/api.py
@@ -17,6 +17,7 @@ from . import util
 from . import languoids
 from . import references
 from .languoids import models
+from .languoids.languoid import NEWICK_TEMPLATE
 
 __all__ = ['Glottolog']
 
@@ -117,14 +118,14 @@ class Glottolog(UnicodeMixin):
     def ascii_tree(self, start, maxlevel=None):
         _ascii_node(self.languoid(start), 0, True, maxlevel, '')
 
-    def newick_tree(self, start=None):
+    def newick_tree(self, start=None, template=NEWICK_TEMPLATE):
         if start:
-            return self.languoid(start).newick_node().newick
+            return self.languoid(start).newick_node(template=template).newick
         nodes = OrderedDict((l.id, l) for l in self.languoids())
         trees = []
         for lang in nodes.values():
             if not lang.lineage and not lang.category.startswith('Pseudo '):
-                ns = lang.newick_node(nodes=nodes).newick
+                ns = lang.newick_node(nodes=nodes, template=template).newick
                 if lang.level == models.Level.language:
                     # an isolate: we wrap it in a pseudo-family with the same name and ID.
                     ns = '({0}){0}'.format(ns)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -40,6 +40,8 @@ def test_newick_tree(api):
         "('isolate [isol1234]-l-':1)'isolate [isol1234]-l-':1;",
         "(('dialect [abcd1236]':1)'language [abcd1235][abc]-l-':1)'family [abcd1234][aaa]':1;"
     }
+    assert api.newick_tree(start='abcd1235', template='{id}') == \
+        "(abcd1236:1)abcd1235:1"
 
 
 def test_hhtypes(api):


### PR DESCRIPTION
Unfortunately I couldn't get `template.format(self)` to work as it doesn't like the Enum in level, and I can't override parameters in the function call (e.g. `template.format(self, name='xx')`) which we'd need to do for some of the display logic. 

Things to note:

1. I don't like the cross-import of NEWICK_TEMPLATE (i.e. both `Glottolog.newick_tree` and `Languoid.newick_node` need it). I could change this so that template defaults to `None` for `Glottolog.newick_tree`, while `Languoid.newick_node` sets template to NEWICK_TEMPLATE if given None. But I figured this was clearer logistically. Thoughts? 

2. This implementation also always means that ISO is  always wrapped in "[...]", which can't be over-ridden by `template`

3. I wondered if the tidying up of `name` with all that string replacing would be useful elsewhere (i.e. as a property `tidy_name` on `Languoid`. 

4. Also note I changed an import of `functools` to just import `total_ordering` rather than the whole module (which was unused).