### PR TITLE
extend endangerment sources and drop subref duplication

### DIFF
--- a/languoids/tree/indo1319/germ1287/nort3152/west2793/high1289/fran1268/east2832/uppe1400/md.ini
+++ b/languoids/tree/indo1319/germ1287/nort3152/west2793/high1289/fran1268/east2832/uppe1400/md.ini
@@ -81,9 +81,6 @@ multitree = sxu
 sub = **hh:hv:Wiesinger:Deutschen**:859-862 (Thuringian) **hh:hv:Wiesinger:Deutschen**:862-865 (Upper Saxon) **hh:hv:Wiesinger:Deutschen**:871-872 (High East Prussian) **hh:hv:Wiesinger:Deutschen**:865-869 (NordobersÃ¤chsisch-SÃ¼dmÃ¤rkisch)
 subrefs = 
 	**hh:hv:Wiesinger:Deutschen**
-	**hh:hv:Wiesinger:Deutschen**
-	**hh:hv:Wiesinger:Deutschen**
-	**hh:hv:Wiesinger:Deutschen**
 
 [endangerment]
 status = not endangered

--- a/languoids/tree/indo1319/germ1287/nort3152/west2793/high1289/fran1268/high1287/midd1319/luxe1241/md.ini
+++ b/languoids/tree/indo1319/germ1287/nort3152/west2793/high1289/fran1268/high1287/midd1319/luxe1241/md.ini
@@ -195,7 +195,6 @@ multitree = ltz
 sub = **hh:hv:Wiesinger:Deutschen**:855-859 (regarding the position of Hessian see **hh:hv:Wiesinger:Deutschen**:849-855 and **hh:hv:Wiesinger:Hessens**)
 subrefs = 
 	**hh:hv:Wiesinger:Deutschen**
-	**hh:hv:Wiesinger:Deutschen**
 	**hh:hv:Wiesinger:Hessens**
 
 [endangerment]

--- a/scripts/treedb.py
+++ b/scripts/treedb.py
@@ -108,7 +108,7 @@ ENDANGERMENT_STATUS = (
     'extinct',
 )
 
-ENDANGERMENT_SOURCE = {'E20', 'ElCat', 'UNESCO', 'Glottolog'}
+ENDANGERMENT_SOURCE = {'E20', 'E21', 'E22', 'ElCat', 'UNESCO', 'Glottolog'}
 
 EL_COMMENT_TYPE = {'Missing', 'Spurious'}
 


### PR DESCRIPTION
Hi Harald, not sure about the uniqueness constraint, is subefs an ordered set or does each element rather correspond to an entry in familyrefs (i.e. allow for duplication)?

- follow-up 44a6e7497d9c18c85db04f621211ce08f58a7332,
  d8f5bc117c5b8482af5a0797a646eb8d09a27a52
- unique(languoid_id, kind) with kind in (familyrefs, subrefs)