### PR TITLE
Added coordinates for sign languages

### DIFF
--- a/languoids/glottolog_signlanguages.csv
+++ b/languoids/glottolog_signlanguages.csv
@@ -1,0 +1,216 @@
+id,name,latitude,longitude
+adam1238,Adamorobe Sign Language,5.834,-0.151
+afgh1239,Afghan Sign Language,34.434167,70.447778
+alba1271,Albanian Sign Language,41.328889,19.817778
+alge1235,Algerian Sign Language,36.4762,3.5462
+alip1234,Alipur Sign Language,16.843564,77.107525
+alsa1242,Al-Sayyid Bedouin Sign Language,31.284444,34.916111
+amam1247,Amami O Shima Sign Language,28.268372,129.358991
+amer1248,American Sign Language,33.81171,278.38791
+anga1315,Angami Naga Sign Language,25.896367,93.719062
+arge1236,Argentine Sign Language,-34.79695,300.82016
+arme1259,Armenian Sign Language,40.10023,44.47668
+aust1252,Austrian Sign Language,48.11967,16.22499
+aust1253,Australian Aborigines Sign Language,-25,135
+aust1271,Australian Sign Language,-30,145
+bama1249,Langue de Signes Malienne,12.651,-8.00136
+bank1251,Ban Khor Sign Language,16.911,103.296
+beng1239,Kata Kolok,-8.383,115.098
+boli1236,Bolivian Sign Language,-16.38949,292.42177
+braz1236,Brazilian Sign Language,-15.49999,312.00001
+brib1244,Bribri Sign Language,9.4,-83.05
+brit1235,British Sign Language,51.66878,-0.4431
+brun1247,Brunca Sign Language,9.978549,-84.821363
+bulg1240,Bulgarian Sign Language,42.79184,25.00265
+bura1295,Bura Sign Language,10.478601,12.284840
+burk1234,Burkina Faso Sign Language,12.363514,-1.5238
+camb1244,Cambodian Sign Language,11.557804,104.870261
+cata1241,Catalan Sign Language,41.635,-1.97
+cent2319,Central Taurus Sign Language,37.000000,33.000000
+chad1238,Chadian Sign Language,12.11145,15.24809
+chat1269,Chatino Sign Language,16.3,-97.316667
+chia1237,Chiangmai Sign Language,18.86295,99.03901
+chil1264,Chilean Sign Language,-32.78099,289.33021
+chin1283,Chinese Sign Language,30.9063,121.569
+chir1296,Chiriqui Sign Languages,8.398055,-82.409271
+colo1249,Colombian Sign Language,5.33532,284.55361
+cost1249,Costa Rican Sign Language,9.8943,275.88197
+croa1242,Croatia Sign Language,45.502,16.796
+cuba1235,Cuba Sign Language,22.061,280.791
+czec1253,Czech Sign Language,50.01201,14.4774
+dani1246,Danish Sign Language,55.82574,12.31866
+domi1236,Dominican Sign Language,18.87983,288.82782
+dutc1253,Dutch Sign Language,52.12512,4.91133
+ecua1243,Ecuadorian Sign Language,-1.24999,280.83335
+egyp1238,Egypt Sign Language,29.567,29.654
+enga1253,Enga Sign Language,-5.416667,143.5
+esto1238,Estonian Sign Language,58.947,24.566
+ethi1238,Ethiopian Sign Language,8.9761,38.85339
+extr1248,Extreme North Cameroon Sign Language,10.597222,14.315833
+finl1235,Finland-Swedish Sign Language,60.39,25.67
+finn1310,Finnish Sign Language,60.66099,25.06767
+fnqi1234,Far North Queensland Indigenous Sign Language,-14.830544,142.923879
+fren1243,French Sign Language,47.0,3.0
+gamb1259,Gambian Sign Language,13.453444,-16.580639
+geor1254,Georgian Sign Language,41.727762,44.813437
+germ1281,German Sign Language,50.81543,7.30478
+ghan1235,Ghanaian Sign Language,5.55225,-0.30274
+ghan1245,Ghandruk Sign Language,28.377,83.807
+ghar1240,Ghardaia Sign Language,32.483333,3.666667
+gree1271,Greek Sign Language,38.05355,23.37624
+guat1249,Guatemalan Sign Language,14.50344,269.43334
+guin1250,Guinean Sign Language,9.553,-13.674
+guin1260,Guinea-Bissau Sign Language,11.859297,-15.591553
+guya1253,Guyana Sign Language,6.795809,-58.151363
+haip1238,Haiphong Sign Language,20.8537,106.68927
+hano1243,Hanoi Sign Language,21.02446,105.8339
+haus1246,Hausa Sign Language,8.486,7.168
+hawa1235,'Hawai'i Pidgin Sign Language',21.63107,201.99821
+hoch1237,Ho Chi Minh City Sign Language,10.78646,106.68073
+hond1239,Honduras Sign Language,14.622,272.776
+hong1241,Hong Kong-Macau Sign Language,22.160631,113.555225
+hung1263,Hungarian Sign Language,47.122,19.264
+icel1236,Icelandic Sign Language,64.17306,-20.27305
+indi1237,Indian Sign Language,27.5186,79.6787
+indo1291,Jakartan Sign Language,-7.908,112.378
+inte1259,International Sign,49.735796,-30.077155
+inui1247,Inuit Sign Language,63.748611,291.480278
+iraq1246,Iraqi Sign Language,33.308738,44.377867
+iris1235,Irish Sign Language,53.31499,-6.36541
+isra1236,Israeli Sign Language,31.5279,34.76366
+ital1275,Italian Sign Language,42.72915,12.42949
+jama1256,Jamaican Country Sign Language,17.99968,-76.93205
+jama1263,Jamaican Sign Language,18.049925,282.241958
+japa1238,Japanese Sign Language,36.02213,139.07918
+jhan1234,Jhankot Sign Language,28.933333,82.9
+jord1238,Levantine Arabic Sign Language,31.82024,36.0829
+juml1239,Jumla Sign Language,29.275278,82.183333
+kafr1234,Kafr Qasem Sign Language,32.1151,34.9751
+kaja1257,Kajana Sign Language,3.888611,-55.572222
+keny1241,Kenyan Sign Language,-1.00166,37.19953
+kere1299,Keresan Pueblo Indian Sign Language,35.503611,-106.723333
+kore1273,Korean Sign Language,37.47179,127.60859
+kurd1260,Kurdish Sign Language,36.829499,44.28591
+kuwa1252,Kuwaiti Sign Language,29.376662,47.98118
+lang1248,Langue des signes de Belgique Francophone,50.8021,4.31312
+lang1335,Langue des Signes Zairoise,-3.62,17.79
+lang1336,Langue des Signes de Bouakako,8.065846,-3.548218
+latv1245,Latvian Sign Language,56.93354,24.4931
+liby1235,Libyan Sign Language,29.512,17.573
+lith1236,Lithuanian Sign Language,55.24867,23.88138
+lyon1239,Lyons Sign Language,48.56422,2.36811
+mada1271,Madagascar Sign Language,-19.04,46.87
+mala1412,Malaysian Sign Language,2.946,101.36596
+malt1238,Maltese Sign Language,35.90695,14.48244
+mara1418,Marajo Sign Language,-0.962912,-49.641656
+mard1245,Mardin Sign Language,37.316667,40.737778
+mari1381,Maritime Sign Language,45.04272,296.11904
+mart1251,'Martha's Vineyard Sign Language',41.414542,-70.625275
+maur1240,Mauritian Sign Language,-20.166667,57.516667
+maxa1248,Maxakali Sign Language,-16.863682,-40.594224
+mbou1245,Mbour Sign Language,14.420649,-16.970045
+mehe1245,Mehek Sign Language,-3.698619,142.501559
+mexi1237,Mexican Sign Language,19.74999,261.50001
+miya1268,Miyakobu Sign Language,34.178195,133.074929
+mofu1251,Mofu-Gudur Sign Language,11,14.5
+mold1243,Moldova Sign Language,47.107,28.694
+mona1241,Monastic Sign Language,41.9026,12.452
+mong1264,Mongolian Sign Language,48.68518,107.5282
+moro1242,Moroccan Sign Language,32.13896,-7.69607
+moza1235,Mozambican Sign Language,-19.811,34.613
+nami1249,Namibian Sign Language,-22.6,17.048
+nana1261,Nanabin Sign Language,5.245634,-0.949953
+nepa1250,Nepalese Sign Language,27.6993,85.30407
+newz1236,New Zealand Sign Language,-39.29225,175.77257
+nica1238,Nicaraguan Sign Language,12.2509,273.66013
+nige1240,Nigerian Sign Language,6.49997,3.16664
+norw1255,Norwegian Sign Language,60.77328,10.24198
+oldb1247,Old Bangkok Sign Language,NA,NA
+oldc1248,Old Cayman Sign Language,19.333333,-81.216667
+oldk1238,Old Kentish Sign Language,51.12,0.98
+orig1234,Original Costa Rican Sign Language,9.935135,-84.010539
+paki1242,Pakistan Sign Language,28.06668,67.88427
+pana1308,Panamanian Sign Language,8.966667,280.466667
+papu1255,Papua New Guinean Sign Language,-9.5,147.116667
+para1318,Paraguayan Sign Language,-25.266667,302.333333
+pena1248,Penang Sign Language,5.375,100.254
+pers1244,Zaban Eshareh Irani,35.69219,51.09964
+peru1235,Peruvian Sign Language,-11.90078,283.17869
+phil1239,Philippine Sign Language,16.91598,121.51221
+plai1235,Plains Indian Sign Language,38.39406,260.75011
+poli1259,Polish Sign Language,52.00414,20.76105
+port1277,Portuguese Sign Language,38.54741,-8.53355
+prov1243,Providencia Sign Language,13.348416,-81.373888
+puer1237,Puerto Rican Sign Language,18.45917,293.90808
+queb1245,Quebec Sign Language,45.99654,285.12807
+roma1324,Romanian Sign Language,44.92922,26.2924
+russ1255,Russian Sign Language,56,44
+salv1237,Salvadoran Sign Language,13.7024,270.40119
+saud1238,Saudi Arabian Sign Language,23.61401,46.47139
+sela1253,Selangor Sign Language,3.13489,101.61389
+sier1246,Sierra Leone Sign Language,8.483,-13.235
+sina1273,Sinasina Sign Language,-6.1,145
+slov1263,Slovakian Sign Language,48.04632,18.12475
+solo1262,Solomon Islands Sign Language,-9.45,159.97
+sout1404,South African Sign Language,-25.96551,28.11864
+span1263,Spanish Sign Language,40.03136,-3.70738
+sril1237,Sri Lankan Sign Language,7.10588,79.85696
+swed1236,Swedish Sign Language,58.92897,16.11326
+swis1235,Swiss-Italian Sign Language,46.30761,8.79111
+swis1240,Swiss-German Sign Language,47.10693,9.07557
+swis1241,Swiss-French Sign Language,46.72252,6.78425
+taiw1241,Taiwan Sign Language,25.02062,121.30519
+tanz1238,Tanzanian Sign Language,-6.82431,39.12697
+tebu1240,Tebul Sign Language,14.499995,-3.499957
+thai1240,Thai Sign Language,13.7837,100.44545
+tibe1277,Tibetan Sign Language,29.651803,91.157981
+trin1277,Trinidad and Tobago Sign Language,10.666667,298.483333
+tuni1249,Tunisian Sign Language,36.49562,10.03348
+turk1288,Turkish Sign Language,41.02675,28.85551
+ugan1238,Ugandan Sign Language,0.2475,32.4829
+ukra1235,Ukrainian Sign Language,50.41113,30.55304
+urub1243,Urubú-Kaapor Sign Language,-2.54091,-46.42134
+urug1238,Uruguayan Sign Language,-34.59671,303.5491
+vale1251,Valencian Sign Language,39.5,-0.75
+vene1237,Venezuelan Sign Language,10.32937,293.23216
+vlaa1235,Vlaamse Gebarentaal,50.8021,4.31312
+yeme1237,Yemeni Sign Language,15.354531,44.200281
+yogy1234,Yogyakarta Sign Langauge,-7.800018,110.368664
+yoln1234,Yolngu Sign Language,-12.283333,136.816667
+yoru1246,Yoruba Sign Language,7.15,3.66
+yuca1236,Yucatec Maya Sign Language,20.49999,-88.99999
+yugo1238,Yugoslavian Sign Language,45.39123,17.519265
+zamb1239,Zambian Sign Language,-15.51343,28.98984
+zimb1247,Zimbabwe Sign Language,-17.9128,31.0216
+angl1242,Anglo-Saxon Monastic Sign Language,NA,NA
+augu1237,Augustinian Sign Language,NA,NA
+bang1373,Bangalore-Madras Indian Sign Language,NA,NA
+bene1236,Benedictine Sign Language,NA,NA
+bomb1264,Bombay Indian Sign Language,NA,NA
+buda1244,Hungarian Sign Language,47.49236,19.052084
+calc1236,Calcutta Indian Sign Language,NA,NA
+cist1236,Cistercian Sign Language,NA,NA
+debr1240,Debrecen,NA,NA
+delh1234,Delhi Indian Sign Language,NA,NA
+eger1238,Eger,NA,NA
+holm1236,Holmestrand,NA,NA
+kaoh1238,Kaohsiung,NA,NA
+kolk1234,Indian Sign Language,22.606042,88.394224
+mars1235,Marseille Sign Language,43.292301,5.370187
+masv1236,Masvingo School Sign,NA,NA
+misk1242,Miskolc,NA,NA
+opor1243,Oporto,NA,NA
+shan1269,Chinese Sign Language,30.91,121.57
+shil1266,Shillong Indian Sign Language,NA,NA
+sopr1238,Sopron,NA,NA
+szeg1238,Szeged,NA,NA
+tain1241,Tainan,NA,NA
+trap1238,Trappist Sign Language,NA,NA
+tron1237,Trondheim,NA,NA
+zimb1235,Zimbabwe Sign Language,-17.91,31.02
+zimb1248,Zimbabwe Community Sign,NA,NA
+inu1247,Inuit Sign Language,63.748611,-68.519722
+nocode_french-harbour,French Harbour Sign Language,16.357260,-86.461386
+nocode_south-rupununi,South Rupununi Sign Language,3.858056,-59.048261
+nocode_douentza-sign,Douentza Sign Languages,15.006344,-2.956465
+nocode_berbey-sign,Berbey Sign Language,15.278462,-1.769086


### PR DESCRIPTION
Manually added coordinates for sign languages. Includes some languages not found in Glottolog as well as "dialects" and old Glottocodes.